### PR TITLE
Added schema versions to media payloads

### DIFF
--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -1,5 +1,5 @@
 TODO: Figure out make options needed for non-api changes
 
 ```
-sphinx-apidoc -f -o reference ../papermill
+sphinx-apidoc -f -o reference ../scrapbook
 ```

--- a/docs/reference/scrapbook.rst
+++ b/docs/reference/scrapbook.rst
@@ -51,6 +51,22 @@ scrapbook.models module
     :undoc-members:
     :show-inheritance:
 
+scrapbook.schemas module
+------------------------
+
+.. automodule:: scrapbook.schemas
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+scrapbook.scraps module
+-----------------------
+
+.. automodule:: scrapbook.scraps
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 scrapbook.version module
 ------------------------
 

--- a/docs/reference/scrapbook.tests.rst
+++ b/docs/reference/scrapbook.tests.rst
@@ -36,6 +36,14 @@ scrapbook.tests.test\_scrapbooks module
     :undoc-members:
     :show-inheritance:
 
+scrapbook.tests.test\_scraps module
+-----------------------------------
+
+.. automodule:: scrapbook.tests.test_scraps
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/scrapbook/api.py
+++ b/scrapbook/api.py
@@ -15,7 +15,9 @@ from IPython.display import display as ip_display
 # We lean on papermill's readers to connect to remote stores
 from papermill.iorw import list_notebook_files
 
-from .models import Notebook, Scrapbook, Scrap, GLUE_PAYLOAD_FMT, scrap_to_payload
+from .models import Notebook, Scrapbook
+from .scraps import Scrap, scrap_to_payload
+from .schemas import GLUE_PAYLOAD_FMT
 from .encoders import registry as encoder_registry
 
 

--- a/scrapbook/exceptions.py
+++ b/scrapbook/exceptions.py
@@ -5,5 +5,13 @@ class ScrapbookException(ValueError):
     """Raised when an exception is encountered when operating on a notebook."""
 
 
-class ScrapbookDataException(ValueError):
+class ScrapbookMissingEncoder(ScrapbookException):
+    """Raised when no encoder is found to tranforming data"""
+
+
+class ScrapbookDataException(ScrapbookException):
     """Raised when a data translation exception is encountered"""
+
+    def __init__(self, message, data_errors=None):
+        super(ScrapbookDataException, self).__init__(message)
+        self.data_errors = data_errors

--- a/scrapbook/models.py
+++ b/scrapbook/models.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-modles.py
+models.py
 
-Provides the varioud model wrapper objects for scrapbook
+Provides the various model wrapper objects for scrapbook
 """
 from __future__ import unicode_literals
 import os

--- a/scrapbook/models.py
+++ b/scrapbook/models.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-notebook.py
+modles.py
 
-Provides the Notebook wrapper objects for scrapbook
+Provides the varioud model wrapper objects for scrapbook
 """
 from __future__ import unicode_literals
 import os
@@ -12,22 +12,21 @@ import collections
 import pandas as pd
 
 from six import string_types
-from collections import namedtuple, OrderedDict
+from collections import OrderedDict
 from IPython.display import display as ip_display, Markdown
 
 # We lean on papermill's readers to connect to remote stores
 from papermill.iorw import papermill_io
 
+from .scraps import Scrap, Scraps, payload_to_scrap, scrap_to_payload
+from .schemas import (
+    GLUE_PAYLOAD_FMT,
+    GLUE_PAYLOAD_PREFIX,
+    RECORD_PAYLOAD_PREFIX,
+    SCRAP_PAYLOAD_PREFIXES,
+)
 from .encoders import registry as encoder_registry
 from .exceptions import ScrapbookException
-
-
-GLUE_PAYLOAD_PREFIX = "application/scrapbook.scrap"
-GLUE_PAYLOAD_FMT = GLUE_PAYLOAD_PREFIX + ".{encoder}+json"
-RECORD_PAYLOAD_PREFIX = "application/papermill.record"
-SCRAP_PAYLOAD_PREFIXES = set(
-    [GLUE_PAYLOAD_PREFIX, RECORD_PAYLOAD_PREFIX]  # Backwards compatibility
-)
 
 
 def merge_dicts(dicts):
@@ -36,58 +35,6 @@ def merge_dicts(dicts):
     for d in iterdicts:
         outcome.update(d)
     return outcome
-
-
-# dataclasses would be nice here...
-Scrap = namedtuple("Scrap", ["name", "data", "encoder", "display"])
-Scrap.__new__.__defaults__ = (None,) * len(Scrap._fields)
-
-
-def scrap_to_payload(scrap):
-    """Translates scrap data to the output format"""
-    # Apply new keys here as needed (like `ref`)
-    return {"name": scrap.name, "data": scrap.data, "encoder": scrap.encoder}
-
-
-def payload_to_scrap(output_payload):
-    """Translates data output format to a scrap"""
-    return Scrap(
-        name=output_payload.get("name"),
-        data=output_payload.get("data"),
-        encoder=output_payload.get("encoder"),
-    )
-
-
-class Scraps(OrderedDict):
-    def __init__(self, *args, **kwargs):
-        super(Scraps, self).__init__(*args, **kwargs)
-
-    @property
-    def data_scraps(self):
-        return OrderedDict([(k, v) for k, v in self.items() if v.data is not None])
-
-    @property
-    def data_dict(self):
-        return {name: scrap.data for name, scrap in self.data_scraps.items()}
-
-    @property
-    def display_scraps(self):
-        return OrderedDict([(k, v) for k, v in self.items() if v.display is not None])
-
-    @property
-    def display_dict(self):
-        return {name: scrap.display for name, scrap in self.display_scraps.items()}
-
-    @property
-    def dataframe(self):
-        """pandas dataframe: dataframe of cell scraps"""
-        return pd.DataFrame(
-            [
-                [scrap.name, scrap.data, scrap.encoder, scrap.display]
-                for scrap in self.values()
-            ],
-            columns=["name", "data", "encoder", "display"],
-        )
 
 
 class Notebook(object):

--- a/scrapbook/schemas.py
+++ b/scrapbook/schemas.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+schemas.py
+
+Provides the json schema for various versions of scrapbook payloads
+"""
+import re
+import os
+import json
+import glob
+
+
+def _load_schema(fname):
+    with open(fname) as f:
+        return json.load(f)
+
+
+GLUE_PAYLOAD_PREFIX = "application/scrapbook.scrap"
+GLUE_PAYLOAD_FMT = GLUE_PAYLOAD_PREFIX + ".{encoder}+json"
+RECORD_PAYLOAD_PREFIX = "application/papermill.record"
+SCRAP_PAYLOAD_PREFIXES = set(
+    [GLUE_PAYLOAD_PREFIX, RECORD_PAYLOAD_PREFIX]  # Backwards compatibility
+)
+
+JSON_FILE_VERSION_REGEX = r".*scrap\.v([0-9]+)\.json"
+SCHEMAS = {
+    int(re.search(JSON_FILE_VERSION_REGEX, fname).group(1)): _load_schema(fname)
+    for fname in glob.glob(
+        os.path.join(os.path.dirname(__file__), "schemas/scrap.v*.json")
+    )
+    if re.match(
+        JSON_FILE_VERSION_REGEX, fname
+    )  # Since glob can't perfectly match the regex
+}
+# Update for any new json payloads and schemas/scrap.v*.json
+LATEST_SCRAP_VERSION = 1
+
+
+def scrap_schema(version=LATEST_SCRAP_VERSION):
+    try:
+        return SCHEMAS[version]
+    except KeyError:
+        raise ValueError("No schema found for version {}".format(version))

--- a/scrapbook/schemas/scrap.v1.json
+++ b/scrapbook/schemas/scrap.v1.json
@@ -1,0 +1,57 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "name",
+    "data",
+    "encoder",
+    "version"
+  ],
+  "properties": {
+    "name": {
+      "$id": "#/properties/name",
+      "type": "string",
+      "title": "scrap name",
+      "description": "Name of the Scrap",
+      "examples": [
+        "name"
+      ]
+    },
+    "data": {
+      "$id": "#/properties/data",
+      "type": [
+        "object",
+        "array",
+        "boolean",
+        "string",
+        "number",
+        "integer"
+      ],
+      "title": "scrap data",
+      "description": "The raw data in JSON format associated with this Scrap",
+      "examples": [
+        "data"
+      ]
+    },
+    "encoder": {
+      "$id": "#/properties/encoder",
+      "type": "string",
+      "title": "scrap encoder",
+      "description": "The encoder key used to encode and decode the \"data\"",
+      "examples": [
+        "json"
+      ]
+    },
+    "version": {
+      "$id": "#/properties/version",
+      "type": "integer",
+      "title": "scrap version",
+      "description": "The version denoting the schema this payload is adhering to",
+      "default": 1,
+      "readOnly": true
+    }
+  }
+}

--- a/scrapbook/scraps.py
+++ b/scrapbook/scraps.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""
+scraps.py
+
+Provides the Scrap and Scraps abstractions for housing data
+"""
+import pandas as pd
+
+from jsonschema import validate as json_validate, ValidationError
+from collections import namedtuple, OrderedDict
+
+from .log import logger
+from .schemas import scrap_schema, LATEST_SCRAP_VERSION
+from .exceptions import ScrapbookDataException
+
+# dataclasses would be nice here...
+Scrap = namedtuple("Scrap", ["name", "data", "encoder", "display"])
+Scrap.__new__.__defaults__ = (None,)
+
+
+def scrap_to_payload(scrap):
+    """Translates scrap data to the output format"""
+    # Apply new keys here as needed (like `ref`)
+    payload = {
+        "name": scrap.name,
+        "data": scrap.data,
+        "encoder": scrap.encoder,
+        "version": LATEST_SCRAP_VERSION,
+    }
+    # Ensure we're conforming to our schema
+    try:
+        json_validate(payload, scrap_schema(LATEST_SCRAP_VERSION))
+    except ValidationError as e:
+        raise ScrapbookDataException(
+            "Scrap (name={name}) contents do not conform to required type structures: {error}".format(
+                name=scrap.name or "None", error=str(e)
+            ),
+            [e],
+        )
+    return payload
+
+
+def payload_to_scrap(payload):
+    """Translates data output format to a scrap"""
+    if "version" not in payload:
+        raise ScrapbookDataException(
+            "Scrap payload (name={}) has no version indicator. "
+            "This scrap is invalid and cannot be loaded".format(
+                payload.get("name", "None")
+            )
+        )
+    if payload["version"] > LATEST_SCRAP_VERSION:
+        logger.warning(
+            "Scrap being loaded was saved with a later payload version ({version})"
+            "than is known by this version of scrapbook ({latest_version}). "
+            "Upgrade scrapbook to ensure data is being loaded as intended".format(
+                version=payload["version"], latest_version=LATEST_SCRAP_VERSION
+            )
+        )
+    else:
+        try:
+            json_validate(payload, scrap_schema(payload["version"]))
+        except ValidationError as e:
+            raise ScrapbookDataException(
+                "Scrap payload (name={name}) contents do not conform to required "
+                "type structures: {error}".format(
+                    name=payload.get("name", "None"), error=str(e)
+                ),
+                [e],
+            )
+    # If future schema versions would require further manipulation
+    # then implement various version loaders here
+    return Scrap(
+        name=payload.get("name"),
+        data=payload.get("data"),
+        encoder=payload.get("encoder"),
+    )
+
+
+class Scraps(OrderedDict):
+    def __init__(self, *args, **kwargs):
+        super(Scraps, self).__init__(*args, **kwargs)
+
+    @property
+    def data_scraps(self):
+        return OrderedDict([(k, v) for k, v in self.items() if v.data is not None])
+
+    @property
+    def data_dict(self):
+        return {name: scrap.data for name, scrap in self.data_scraps.items()}
+
+    @property
+    def display_scraps(self):
+        return OrderedDict([(k, v) for k, v in self.items() if v.display is not None])
+
+    @property
+    def display_dict(self):
+        return {name: scrap.display for name, scrap in self.display_scraps.items()}
+
+    @property
+    def dataframe(self):
+        """pandas dataframe: dataframe of cell scraps"""
+        return pd.DataFrame(
+            [
+                [scrap.name, scrap.data, scrap.encoder, scrap.display]
+                for scrap in self.values()
+            ],
+            columns=["name", "data", "encoder", "display"],
+        )

--- a/scrapbook/tests/__init__.py
+++ b/scrapbook/tests/__init__.py
@@ -1,5 +1,12 @@
 import os
 
+# Work-around for https://github.com/Julian/jsonschema/issues/477
+from jsonschema.exceptions import _Error
+
+_Error.__eq__ = object.__eq__
+_Error.__ne__ = object.__ne__
+_Error.__hash__ = object.__hash__
+
 
 def get_fixture_path(*args):
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures", *args)

--- a/scrapbook/tests/notebooks/collection/result1.ipynb
+++ b/scrapbook/tests/notebooks/collection/result1.ipynb
@@ -28,7 +28,8 @@
       "application/scrapbook.scrap.json+json": {
        "name": "one",
        "data": 1,
-       "encoder": "json"
+       "encoder": "json",
+       "version": 1
       }
      },
      "metadata": {},

--- a/scrapbook/tests/notebooks/collection/result2.ipynb
+++ b/scrapbook/tests/notebooks/collection/result2.ipynb
@@ -28,7 +28,8 @@
       "application/scrapbook.scrap.json+json": {
        "name": "two",
        "data": 2,
-       "encoder": "json"
+       "encoder": "json",
+       "version": 1
       }
      },
      "metadata": {},

--- a/scrapbook/tests/test_api.py
+++ b/scrapbook/tests/test_api.py
@@ -8,8 +8,8 @@ import collections
 from IPython.display import Image
 
 from . import get_fixture_path
-from ..models import GLUE_PAYLOAD_FMT
 from ..api import glue
+from ..schemas import GLUE_PAYLOAD_FMT
 
 
 @pytest.mark.parametrize(
@@ -24,6 +24,7 @@ from ..api import glue
                     "name": "foobarbaz",
                     "data": {"foo": "bar", "baz": 1},
                     "encoder": "json",
+                    "version": 1,
                 }
             },
             {"scrapbook": {"name": "foobarbaz"}},
@@ -37,6 +38,7 @@ from ..api import glue
                     "name": "foobarbaz",
                     "data": '{"foo":"bar","baz":1}',
                     "encoder": "text",
+                    "version": 1,
                 }
             },
             {"scrapbook": {"name": "foobarbaz"}},
@@ -50,6 +52,7 @@ from ..api import glue
                     "name": "foobarbaz",
                     "data": {"foo": "bar", "baz": 1},
                     "encoder": "json",
+                    "version": 1,
                 }
             },
             {"scrapbook": {"name": "foobarbaz"}},
@@ -64,6 +67,7 @@ from ..api import glue
                     "name": "foobarbaz",
                     "data": {"foo": "bar", "baz": 1},
                     "encoder": "json",
+                    "version": 1,
                 }
             },
             {"scrapbook": {"name": "foobarbaz"}},
@@ -145,6 +149,7 @@ def test_glue_display_only(mock_display, name, obj, data, encoder, metadata, dis
                     "name": "foobarbaz",
                     "data": "foo,bar,baz",
                     "encoder": "text",
+                    "version": 1,
                 }
             },
             {u"text/plain": u"'foo,bar,baz'"},
@@ -160,6 +165,7 @@ def test_glue_display_only(mock_display, name, obj, data, encoder, metadata, dis
                     "name": "foobarbaz",
                     "data": ["foo", "bar", "baz"],
                     "encoder": "json",
+                    "version": 1,
                 }
             },
             {u"text/plain": u"['foo', 'bar', 'baz']"},

--- a/scrapbook/tests/test_notebooks.py
+++ b/scrapbook/tests/test_notebooks.py
@@ -112,6 +112,7 @@ def test_reglue_scrap(mock_display, notebook_result):
                 "name": "one",
                 "data": 1,
                 "encoder": "json",
+                "version": 1,
             }
         },
         metadata={"scrapbook": {"name": "one"}},
@@ -192,7 +193,13 @@ def test_scrap_dataframe(notebook_result):
         ],
         columns=["name", "data", "encoder", "display", "filename"],
     )
-    assert_frame_equal(notebook_result.scrap_dataframe, expected_df, check_exact=True)
+    assert_frame_equal(
+        notebook_result.scrap_dataframe,
+        expected_df,
+        # Python 2.7 gets confused here with AnyDict / None sometimes
+        check_exact=True,
+        check_column_type=False,
+    )
 
 
 def test_papermill_dataframe(notebook_result):

--- a/scrapbook/tests/test_scrapbooks.py
+++ b/scrapbook/tests/test_scrapbooks.py
@@ -11,7 +11,7 @@ from pandas.util.testing import assert_frame_equal
 
 from . import get_notebook_path
 from .. import read_notebooks
-from ..models import Scrap, Scraps
+from ..scraps import Scrap, Scraps
 
 
 class AnyMarkdownWith(Markdown):

--- a/scrapbook/tests/test_scraps.py
+++ b/scrapbook/tests/test_scraps.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import mock
+import pytest
+
+from ..scraps import Scrap, scrap_to_payload, payload_to_scrap
+from ..schemas import LATEST_SCRAP_VERSION
+from ..exceptions import ScrapbookDataException
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (
+            Scrap(name="foo", data='{"foo":"bar","baz":1}', encoder="text"),
+            {
+                "name": "foo",
+                "data": '{"foo":"bar","baz":1}',
+                "encoder": "text",
+                "version": LATEST_SCRAP_VERSION,
+            },
+        ),
+        (
+            Scrap(name="foo", data={"foo": "bar", "baz": 1}, encoder="json"),
+            {
+                "name": "foo",
+                "data": {"foo": "bar", "baz": 1},
+                "encoder": "json",
+                "version": LATEST_SCRAP_VERSION,
+            },
+        ),
+        (
+            Scrap(name="foo", data=["foo", "bar", 1, 2, 3], encoder="json"),
+            {
+                "name": "foo",
+                "data": ["foo", "bar", 1, 2, 3],
+                "encoder": "json",
+                "version": LATEST_SCRAP_VERSION,
+            },
+        ),
+        (
+            Scrap(name="foo", data=[u"😍"], encoder="json"),
+            {
+                "name": "foo",
+                "data": [u"😍"],
+                "encoder": "json",
+                "version": LATEST_SCRAP_VERSION,
+            },
+        ),
+    ],
+)
+def test_scrap_to_payload(test_input, expected):
+    assert scrap_to_payload(test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (
+            {
+                "name": "foo",
+                "data": '{"foo":"bar","baz":1}',
+                "encoder": "text",
+                "version": LATEST_SCRAP_VERSION,
+            },
+            Scrap(name="foo", data='{"foo":"bar","baz":1}', encoder="text"),
+        ),
+        (
+            {
+                "name": "foo",
+                "data": {"foo": "bar", "baz": 1},
+                "encoder": "json",
+                "version": LATEST_SCRAP_VERSION,
+            },
+            Scrap(name="foo", data={"foo": "bar", "baz": 1}, encoder="json"),
+        ),
+        (
+            {
+                "name": "foo",
+                "data": ["foo", "bar", 1, 2, 3],
+                "encoder": "json",
+                "version": LATEST_SCRAP_VERSION,
+            },
+            Scrap(name="foo", data=["foo", "bar", 1, 2, 3], encoder="json"),
+        ),
+        (
+            {
+                "name": "foo",
+                "data": [u"😍"],
+                "encoder": "json",
+                "version": LATEST_SCRAP_VERSION,
+            },
+            Scrap(name="foo", data=[u"😍"], encoder="json"),
+        ),
+    ],
+)
+def test_payload_to_scrap(test_input, expected):
+    assert payload_to_scrap(test_input) == expected
+
+
+class InvalidData(object):
+    pass
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        Scrap(name="foo", data='{"foo":"bar","baz":1}', encoder=None),
+        Scrap(name="foo", data=None, encoder="json"),
+        Scrap(name=None, data=["foo", "bar", 1, 2, 3], encoder="json"),
+        Scrap(name="foo", data=InvalidData(), encoder="custom"),
+    ],
+)
+def test_scrap_to_payload_validation_error(test_input):
+    with pytest.raises(ScrapbookDataException):
+        scrap_to_payload(test_input)
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        {
+            "name": "foo",
+            "data": '{"foo":"bar","baz":1}',
+            "encoder": None,
+            "version": LATEST_SCRAP_VERSION,
+        },
+        {
+            "name": "foo",
+            "data": None,
+            "encoder": "json",
+            "version": LATEST_SCRAP_VERSION,
+        },
+        {
+            "name": None,
+            "data": ["foo", "bar", 1, 2, 3],
+            "encoder": "json",
+            "version": LATEST_SCRAP_VERSION,
+        },
+        {
+            "name": "foo",
+            "data": InvalidData(),
+            "encoder": "custom",
+            "version": LATEST_SCRAP_VERSION,
+        },
+    ],
+)
+def test_payload_to_scrap_validation_error(test_input):
+    with pytest.raises(ScrapbookDataException):
+        payload_to_scrap(test_input)
+
+
+@mock.patch("scrapbook.scraps.logger")
+def test_payload_to_scrap_later_version(mock_logging):
+    assert payload_to_scrap(
+        {
+            "name": "foo",
+            "data": {"foo": "bar", "baz": 1},
+            "encoder": "json",
+            "version": LATEST_SCRAP_VERSION + 1,
+        }
+    ) == Scrap(name="foo", data={"foo": "bar", "baz": 1}, encoder="json")
+    # Should emit a warning that it might not be able to parse the payload
+    assert mock_logging.warning.called
+
+
+@mock.patch("scrapbook.scraps.logger")
+def test_payload_to_scrap_later_version_mismatch(mock_logging):
+    # Try as best as can be done to match fields when version is higher
+    assert payload_to_scrap(
+        {
+            "changed_": "foo",
+            "changed_data": {"foo": "bar", "baz": 1},
+            "changed_encoder": "json",
+            "version": LATEST_SCRAP_VERSION + 1,
+        }
+    ) == Scrap(name=None, data=None, encoder=None)
+    # Should emit a warning that it might not be able to parse the payload
+    assert mock_logging.warning.called

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/nteract/scrapbook",
     packages=["scrapbook"],
+    include_package_data=True,
     install_requires=read_reqs("requirements.txt"),
     extras_require=extras_require,
     project_urls={


### PR DESCRIPTION
- Now scrapbook/schemas/*.json will contain json schema files for evaluating payloads in display outputs.
- Changed validation logic for decode/endcode functions to lean on jsonschema checks.
- Scraps moved to their own file to avoid circular import issues
- "version" added the output payload
- More tests