### PR TITLE
Fixed reading string json elements from notebook store

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,8 @@ twine>=1.11.0
 flake8
 tox
 mock
+ipython
+papermill
 pytest>=4.1
 pytest-cov>=2.6.1
 pytest-mock>=1.10

--- a/scrapbook/encoders.py
+++ b/scrapbook/encoders.py
@@ -11,6 +11,11 @@ import collections
 from .scraps import scrap_to_payload
 from .exceptions import ScrapbookException, ScrapbookMissingEncoder
 
+try:
+    from json import JSONDecodeError  # Py 3
+except ImportError:
+    JSONDecodeError = ValueError  # Py 2
+
 
 class DataEncoderRegistry(collections.MutableMapping):
     def __init__(self):
@@ -124,7 +129,7 @@ class JsonEncoder(object):
         try:
             if isinstance(scrap.data, six.string_types):
                 scrap = scrap._replace(data=json.loads(scrap.data))
-        except json.JSONDecodeError:
+        except JSONDecodeError:
             # The string is an actual string and not a json string, so don't modify
             pass
         return scrap

--- a/scrapbook/encoders.py
+++ b/scrapbook/encoders.py
@@ -121,8 +121,12 @@ class JsonEncoder(object):
 
     def decode(self, scrap, **kwargs):
         # Just in case we somehow got a valid JSON string pushed
-        if isinstance(scrap.data, six.string_types):
-            scrap = scrap._replace(data=json.loads(scrap.data))
+        try:
+            if isinstance(scrap.data, six.string_types):
+                scrap = scrap._replace(data=json.loads(scrap.data))
+        except json.JSONDecodeError:
+            # The string is an actual string and not a json string, so don't modify
+            pass
         return scrap
 
 

--- a/scrapbook/tests/notebooks/collection/result1.ipynb
+++ b/scrapbook/tests/notebooks/collection/result1.ipynb
@@ -12,67 +12,114 @@
    "source": [
     "# Parameters\n",
     "foo = 1\n",
-    "bar = \"hello\"\n"
+    "bar = \"hello\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "papermill": {"duration": 0.123},
+    "papermill": {
+     "duration": 0.123
+    },
     "tags": []
    },
    "outputs": [
     {
      "data": {
       "application/scrapbook.scrap.json+json": {
-       "name": "one",
        "data": 1,
        "encoder": "json",
+       "name": "one",
        "version": 1
       }
      },
      "metadata": {
-       "scrapbook": {
-        "name": "one",
-        "data": true,
-        "display": false
-       }
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/papermill.record+json": {
-       "number": 1
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "one"
       }
      },
-     "metadata": {},
      "output_type": "display_data"
     },
     {
      "data": {
-      "application/papermill.record+json": {
-       "list": [
+      "application/scrapbook.scrap.json+json": {
+       "data": 1,
+       "encoder": "json",
+       "name": "number",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "number"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": [
         1,
         2,
         3
-       ]
+       ],
+       "encoder": "json",
+       "name": "list",
+       "version": 1
       }
      },
-     "metadata": {},
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "list"
+      }
+     },
      "output_type": "display_data"
     },
     {
      "data": {
-      "application/papermill.record+json": {
-       "dict": {
+      "application/scrapbook.scrap.json+json": {
+       "data": {
         "a": 1,
         "b": 2
-       }
+       },
+       "encoder": "json",
+       "name": "dict",
+       "version": 1
       }
      },
-     "metadata": {},
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "dict"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.text+json": {
+       "data": "Hello World!",
+       "encoder": "text",
+       "name": "output",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "output"
+      }
+     },
      "output_type": "display_data"
     },
     {
@@ -82,8 +129,28 @@
       ]
      },
      "metadata": {
-      "papermill": {
+      "scrapbook": {
+       "data": false,
+       "display": true,
        "name": "output"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.text+json": {
+       "data": "Just here!",
+       "encoder": "text",
+       "name": "one_only",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "one_only"
       }
      },
      "output_type": "display_data"
@@ -96,9 +163,9 @@
      },
      "metadata": {
       "scrapbook": {
-       "name": "one_only",
        "data": false,
-       "display": true
+       "display": true,
+       "name": "one_only"
       }
      },
      "output_type": "display_data"
@@ -112,8 +179,8 @@
     "sb.glue(\"list\", [1,2,3])\n",
     "sb.glue(\"dict\", dict(a=1, b=2))\n",
     "\n",
-    "sb.sketch(\"output\", \"Hello World!\")",
-    "sb.sketch(\"one_only\", \"Just here!\")"
+    "sb.glue(\"output\", \"Hello World!\", display=True)\n",
+    "sb.glue(\"one_only\", \"Just here!\", display=True)"
    ]
   }
  ],
@@ -121,21 +188,21 @@
   "celltoolbar": "Tags",
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2.0
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
   },
   "papermill": {
    "environment_variables": {},
@@ -150,5 +217,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/scrapbook/tests/notebooks/collection/result2.ipynb
+++ b/scrapbook/tests/notebooks/collection/result2.ipynb
@@ -12,67 +12,114 @@
    "source": [
     "# Parameters\n",
     "foo = 2\n",
-    "bar = \"world\"\n"
+    "bar = \"world\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "papermill": {"duration": 0.456},
+    "papermill": {
+     "duration": 0.456
+    },
     "tags": []
    },
    "outputs": [
     {
      "data": {
       "application/scrapbook.scrap.json+json": {
-       "name": "two",
        "data": 2,
        "encoder": "json",
+       "name": "two",
        "version": 1
       }
      },
      "metadata": {
-       "scrapbook": {
-        "name": "two",
-        "data": true,
-        "display": false
-       }
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/papermill.record+json": {
-       "number": 2
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "two"
       }
      },
-     "metadata": {},
      "output_type": "display_data"
     },
     {
      "data": {
-      "application/papermill.record+json": {
-       "list": [
+      "application/scrapbook.scrap.json+json": {
+       "data": 2,
+       "encoder": "json",
+       "name": "number",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "number"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": [
         4,
         5,
         6
-       ]
+       ],
+       "encoder": "json",
+       "name": "list",
+       "version": 1
       }
      },
-     "metadata": {},
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "list"
+      }
+     },
      "output_type": "display_data"
     },
     {
      "data": {
-      "application/papermill.record+json": {
-       "dict": {
+      "application/scrapbook.scrap.json+json": {
+       "data": {
         "a": 3,
         "b": 4
-       }
+       },
+       "encoder": "json",
+       "name": "dict",
+       "version": 1
       }
      },
-     "metadata": {},
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "dict"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.text+json": {
+       "data": "Hello World 2!",
+       "encoder": "text",
+       "name": "output",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "output"
+      }
+     },
      "output_type": "display_data"
     },
     {
@@ -82,8 +129,28 @@
       ]
      },
      "metadata": {
-      "papermill": {
+      "scrapbook": {
+       "data": false,
+       "display": true,
        "name": "output"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.text+json": {
+       "data": "Just here!",
+       "encoder": "text",
+       "name": "two_only",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "two_only"
       }
      },
      "output_type": "display_data"
@@ -96,9 +163,9 @@
      },
      "metadata": {
       "scrapbook": {
-       "name": "two_only",
        "data": false,
-       "display": true
+       "display": true,
+       "name": "two_only"
       }
      },
      "output_type": "display_data"
@@ -112,8 +179,8 @@
     "sb.glue(\"list\", [4,5,6])\n",
     "sb.glue(\"dict\", dict(a=3, b=4))\n",
     "\n",
-    "sb.sketch(\"output\", \"Hello World 2!\")",
-    "sb.sketch(\"two_only\", \"Just here!\")"
+    "sb.glue(\"output\", \"Hello World 2!\", display=True)\n",
+    "sb.glue(\"two_only\", \"Just here!\", display=True)"
    ]
   }
  ],
@@ -121,21 +188,21 @@
   "celltoolbar": "Tags",
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2.0
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
   },
   "papermill": {
    "environment_variables": {},
@@ -150,5 +217,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/scrapbook/tests/notebooks/record.ipynb
+++ b/scrapbook/tests/notebooks/record.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import papermill as pm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/mseal/.py3local/lib/python3.6/site-packages/ipykernel_launcher.py:1: DeprecationWarning: Function record is deprecated and will be removed in verison 1.0.0 (current version 0.19.1). Please see `scrapbook.glue` (nteract-scrapbook) as a replacement for this functionality.\n",
+      "  \"\"\"Entry point for launching an IPython kernel.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/papermill.record+json": {
+       "hello": "world"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/mseal/.py3local/lib/python3.6/site-packages/ipykernel_launcher.py:2: DeprecationWarning: Function record is deprecated and will be removed in verison 1.0.0 (current version 0.19.1). Please see `scrapbook.glue` (nteract-scrapbook) as a replacement for this functionality.\n",
+      "  \n"
+     ]
+    },
+    {
+     "data": {
+      "application/papermill.record+json": {
+       "number": 123
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/mseal/.py3local/lib/python3.6/site-packages/ipykernel_launcher.py:3: DeprecationWarning: Function record is deprecated and will be removed in verison 1.0.0 (current version 0.19.1). Please see `scrapbook.glue` (nteract-scrapbook) as a replacement for this functionality.\n",
+      "  This is separate from the ipykernel package so we can avoid doing imports until\n"
+     ]
+    },
+    {
+     "data": {
+      "application/papermill.record+json": {
+       "some_list": [
+        1,
+        3,
+        5
+       ]
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/mseal/.py3local/lib/python3.6/site-packages/ipykernel_launcher.py:4: DeprecationWarning: Function record is deprecated and will be removed in verison 1.0.0 (current version 0.19.1). Please see `scrapbook.glue` (nteract-scrapbook) as a replacement for this functionality.\n",
+      "  after removing the cwd from sys.path.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/papermill.record+json": {
+       "some_dict": {
+        "a": 1,
+        "b": 2
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/mseal/.py3local/lib/python3.6/site-packages/ipykernel_launcher.py:5: DeprecationWarning: Function display is deprecated and will be removed in verison 1.0.0 (current version 0.19.1). Please see `scrapbook.glue` (nteract-scrapbook) as a replacement for this functionality.\n",
+      "  \"\"\"\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Text'"
+      ]
+     },
+     "metadata": {
+      "papermill": {
+       "name": "some_display"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pm.record(\"hello\", \"world\")\n",
+    "pm.record(\"number\", 123)\n",
+    "pm.record(\"some_list\", [1, 3, 5])\n",
+    "pm.record(\"some_dict\", {\"a\": 1, \"b\": 2})\n",
+    "pm.display(\"some_display\", \"Text\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/scrapbook/tests/test_encoders.py
+++ b/scrapbook/tests/test_encoders.py
@@ -55,8 +55,8 @@ def test_json_decode(test_input, expected):
     ],
 )
 def test_json_decode_failures(test_input):
-    with pytest.raises(JSONDecodeError):
-        JsonEncoder().decode(test_input)
+    # If it can't decode, leaves the string as expected
+    assert JsonEncoder().decode(test_input) == test_input
 
 
 @pytest.mark.parametrize(

--- a/scrapbook/tests/test_scrapbooks.py
+++ b/scrapbook/tests/test_scrapbooks.py
@@ -76,7 +76,13 @@ def test_notebook_scraps(notebook_collection):
                                 encoder="display",
                                 display={
                                     "data": {"text/plain": "'Hello World!'"},
-                                    "metadata": {"papermill": {"name": "output"}},
+                                    "metadata": {
+                                        "scrapbook": {
+                                            "name": "output",
+                                            "data": False,
+                                            "display": True,
+                                        }
+                                    },
                                     "output_type": "display_data",
                                 },
                             ),
@@ -141,7 +147,13 @@ def test_notebook_scraps(notebook_collection):
                                 encoder="display",
                                 display={
                                     "data": {"text/plain": "'Hello World 2!'"},
-                                    "metadata": {"papermill": {"name": "output"}},
+                                    "metadata": {
+                                        "scrapbook": {
+                                            "name": "output",
+                                            "data": False,
+                                            "display": True,
+                                        }
+                                    },
                                     "output_type": "display_data",
                                 },
                             ),
@@ -190,7 +202,13 @@ def test_scraps(notebook_collection):
                     encoder="display",
                     display={
                         "data": {"text/plain": "'Hello World 2!'"},
-                        "metadata": {"papermill": {"name": "output"}},
+                        "metadata": {
+                            "scrapbook": {
+                                "data": False,
+                                "display": True,
+                                "name": "output",
+                            }
+                        },
                         "output_type": "display_data",
                     },
                 ),
@@ -205,9 +223,9 @@ def test_scraps(notebook_collection):
                         "data": {"text/plain": "'Just here!'"},
                         "metadata": {
                             "scrapbook": {
-                                "name": "one_only",
                                 "data": False,
                                 "display": True,
+                                "name": "one_only",
                             }
                         },
                         "output_type": "display_data",
@@ -225,9 +243,9 @@ def test_scraps(notebook_collection):
                         "data": {"text/plain": "'Just here!'"},
                         "metadata": {
                             "scrapbook": {
-                                "name": "two_only",
                                 "data": False,
                                 "display": True,
+                                "name": "two_only",
                             }
                         },
                         "output_type": "display_data",


### PR DESCRIPTION
Fixes https://github.com/nteract/scrapbook/issues/43

Also record backwards compatibility tests were isolated to a separate notebook / tests rather than combining with the collection tests that read result1 and result2. Thus the large notebook changes can mostly be ignored as they're just rerunning the notebook with current api contract calls.