### PR TITLE
Error is thrown when using GET parameters on cloud storage paths

### DIFF
--- a/scrapbook/models.py
+++ b/scrapbook/models.py
@@ -10,6 +10,7 @@ import copy
 import nbformat
 import collections
 import pandas as pd
+from urllib import parse
 
 from six import string_types
 from collections import OrderedDict
@@ -48,9 +49,9 @@ class Notebook(object):
 
     def __init__(self, node_or_path):
         if isinstance(node_or_path, string_types):
-
-            if ".ipynb" not in node_or_path:
-                raise ValueError(
+            path = parse.urlparse(node_or_path).path
+            if not os.path.splitext(path)[-1].endswith('ipynb'):
+                raise Warning(
                     "Requires an '.ipynb' file extension. Provided path: '{}'".format(
                         node_or_path
                     )

--- a/scrapbook/models.py
+++ b/scrapbook/models.py
@@ -48,7 +48,8 @@ class Notebook(object):
 
     def __init__(self, node_or_path):
         if isinstance(node_or_path, string_types):
-            if not node_or_path.endswith(".ipynb"):
+
+            if ".ipynb" not in node_or_path:
                 raise ValueError(
                     "Requires an '.ipynb' file extension. Provided path: '{}'".format(
                         node_or_path

--- a/scrapbook/models.py
+++ b/scrapbook/models.py
@@ -10,7 +10,13 @@ import copy
 import nbformat
 import collections
 import pandas as pd
-from urllib import parse
+import sys
+
+if sys.version_info > (3, 0, 0):
+    from urllib import parse
+    urlparse = parse.urlparse
+else:
+    from urlparse import urlparse
 
 from six import string_types
 from collections import OrderedDict
@@ -49,7 +55,7 @@ class Notebook(object):
 
     def __init__(self, node_or_path):
         if isinstance(node_or_path, string_types):
-            path = parse.urlparse(node_or_path).path
+            path = urlparse(node_or_path).path
             if not os.path.splitext(path)[-1].endswith('ipynb'):
                 raise Warning(
                     "Requires an '.ipynb' file extension. Provided path: '{}'".format(

--- a/scrapbook/models.py
+++ b/scrapbook/models.py
@@ -10,7 +10,6 @@ import copy
 import nbformat
 import collections
 import pandas as pd
-import sys
 
 from six import string_types
 from collections import OrderedDict
@@ -25,11 +24,10 @@ from .encoders import registry as encoder_registry
 from .exceptions import ScrapbookException
 from .utils import kernel_required, deprecated
 
-if sys.version_info > (3, 0, 0):
-    from urllib import parse
-    urlparse = parse.urlparse
-else:
-    from urlparse import urlparse
+try:
+    from urllib.parse import urlparse  # Py3
+except ImportError:
+    from urlparse import urlparse  # Py2
 
 
 def merge_dicts(dicts):

--- a/scrapbook/models.py
+++ b/scrapbook/models.py
@@ -12,12 +12,6 @@ import collections
 import pandas as pd
 import sys
 
-if sys.version_info > (3, 0, 0):
-    from urllib import parse
-    urlparse = parse.urlparse
-else:
-    from urlparse import urlparse
-
 from six import string_types
 from collections import OrderedDict
 from IPython.display import display as ip_display, Markdown
@@ -30,6 +24,12 @@ from .schemas import GLUE_PAYLOAD_PREFIX, RECORD_PAYLOAD_PREFIX
 from .encoders import registry as encoder_registry
 from .exceptions import ScrapbookException
 from .utils import kernel_required, deprecated
+
+if sys.version_info > (3, 0, 0):
+    from urllib import parse
+    urlparse = parse.urlparse
+else:
+    from urlparse import urlparse
 
 
 def merge_dicts(dicts):

--- a/scrapbook/tests/test_notebooks.py
+++ b/scrapbook/tests/test_notebooks.py
@@ -3,6 +3,7 @@
 import mock
 import pytest
 import collections
+import json
 
 import pandas as pd
 
@@ -56,12 +57,22 @@ def test_bad_ext():
 
 @mock.patch("papermill.iorw.papermill_io.read")
 def test_good_ext_for_url(mock_read):
+    sample_output = {
+        "cells": [{
+            "cell_type": "code",
+            "execution_count": 1,
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        }]
+    }
+
+    mock_read.return_value = json.dumps(sample_output)
+
     params = "?sig=some-unique-secret-token"
     url = "abs://mystorage.blob.core.windows.net/my-actual-notebook.ipynb" + params
-    try:
-        Notebook(url)
-    except TypeError:
-        pass  # this means no valid json is returned by the reader
+
+    Notebook(url)
 
     mock_read.assert_called_once()
 

--- a/scrapbook/tests/test_notebooks.py
+++ b/scrapbook/tests/test_notebooks.py
@@ -13,7 +13,7 @@ from . import get_notebook_path, get_notebook_dir
 from .. import read_notebook, utils
 from ..models import Notebook
 from ..exceptions import ScrapbookException
-
+from papermill.exceptions import PapermillOptionalDependencyException
 
 try:
     FileNotFoundError
@@ -51,8 +51,18 @@ def test_bad_path():
 
 
 def test_bad_ext():
-    with pytest.raises(ValueError):
+    with pytest.raises(Warning):
         Notebook("not/a/valid/extension.py")
+
+
+def test_good_ext_for_url():
+    with pytest.raises(PapermillOptionalDependencyException):
+        Notebook("abs://mystorage.blob.core.windows.net/my-actual-notebook.ipynb?sig=some-unique-secret-token")
+
+
+def test_bad_ext_for_url():
+    with pytest.raises(Warning):
+        Notebook("abs://mystorage.blob.core.windows.net/my-actual-notebook.txt?sig=some-unique-secret-token")
 
 
 def test_filename(notebook_result):

--- a/scrapbook/tests/test_notebooks.py
+++ b/scrapbook/tests/test_notebooks.py
@@ -57,12 +57,16 @@ def test_bad_ext():
 
 def test_good_ext_for_url():
     with pytest.raises(PapermillOptionalDependencyException):
-        Notebook("abs://mystorage.blob.core.windows.net/my-actual-notebook.ipynb?sig=some-unique-secret-token")
+        params = "?sig=some-unique-secret-token"
+        url = "abs://mystorage.blob.core.windows.net/my-actual-notebook.ipynb" + params
+        Notebook(url)
 
 
 def test_bad_ext_for_url():
     with pytest.raises(Warning):
-        Notebook("abs://mystorage.blob.core.windows.net/my-actual-notebook.txt?sig=some-unique-secret-token")
+        params = "?sig=some-unique-secret-token"
+        url = "abs://mystorage.blob.core.windows.net/my-actual-notebook.txt" + params
+        Notebook(url)
 
 
 def test_filename(notebook_result):

--- a/scrapbook/tests/test_notebooks.py
+++ b/scrapbook/tests/test_notebooks.py
@@ -55,11 +55,16 @@ def test_bad_ext():
         Notebook("not/a/valid/extension.py")
 
 
-def test_good_ext_for_url():
-    with pytest.raises(PapermillOptionalDependencyException):
-        params = "?sig=some-unique-secret-token"
-        url = "abs://mystorage.blob.core.windows.net/my-actual-notebook.ipynb" + params
+@mock.patch("papermill.iorw.papermill_io.read")
+def test_good_ext_for_url(mock_read):
+    params = "?sig=some-unique-secret-token"
+    url = "abs://mystorage.blob.core.windows.net/my-actual-notebook.ipynb" + params
+    try:
         Notebook(url)
+    except TypeError:
+        pass  # this means no valid json is returned by the reader
+
+    mock_read.assert_called_once()
 
 
 def test_bad_ext_for_url():

--- a/scrapbook/tests/test_notebooks.py
+++ b/scrapbook/tests/test_notebooks.py
@@ -13,7 +13,6 @@ from . import get_notebook_path, get_notebook_dir
 from .. import read_notebook, utils
 from ..models import Notebook
 from ..exceptions import ScrapbookException
-from papermill.exceptions import PapermillOptionalDependencyException
 
 try:
     FileNotFoundError


### PR DESCRIPTION
## Behaviour

As context, we're storing and reading papermill log data on Azure blob storage. Take the following snippet as an example;

```
import papermill as pm
import scrapbook as sb
import azure.common as ac
import json

papermill_log_output_query_string = "?sig=some-unique-secret-token"

nb_path = "abs://mystorage.blob.core.windows.net/my-actual-notebook.ipynb"

try:
    nb = sb.read_notebook(nb_path + papermill_log_output_query_string)
except ac.AzureMissingResourceHttpError as err:
    logging.info(err)
```

This raises the following error;

```
ValueError: Requires an '.ipynb' file extension. Provided path:...
```

## Expected behaviour

* Azure allows users to provide GET parameters along with the file URL, to enable authorization. In this case an access token. 
* The file should pass, and not raise an extention error


## Suggested solution

* Raise a warning instead of an error
* Or check for GET parameters in the provided urL when cloud storage like Blob or S3 is used. 



I liked the original behaviour of `papermill.record()` which smply raised a warning on the supposedly missing extention. Seeing the warning triggered a developer response of "hey, i've provided a GET parameter in the URL so this is probably fine." 

Not throwing an error possibly hinders developers that provide a faulty path but may no longer notice. Any thoughts on this? 