### PR TITLE
Changes ipython import to be lazy, saving on initial import times

### DIFF
--- a/scrapbook/api.py
+++ b/scrapbook/api.py
@@ -7,11 +7,7 @@ Provides the base API calls for scrapbook
 from __future__ import unicode_literals
 import os
 
-import IPython
-
 from six import string_types
-
-from IPython.display import display as ip_display
 
 # We lean on papermill's readers to connect to remote stores
 from papermill.iorw import list_notebook_files
@@ -67,6 +63,9 @@ def glue(name, scrap, encoder=None, display=None):
     display: any (optional)
         An indicator for persisting controlling displays for the named record.
     """
+    # Keep slow import lazy
+    import IPython
+    from IPython.display import display as ip_display
 
     # TODO: Implement the cool stuff. Remote storage indicators?!? Maybe remote media type?!?
     # TODO: Make this more modular

--- a/scrapbook/models.py
+++ b/scrapbook/models.py
@@ -13,7 +13,6 @@ import pandas as pd
 
 from six import string_types
 from collections import OrderedDict
-from IPython.display import display as ip_display, Markdown
 
 # We lean on papermill's readers to connect to remote stores
 from papermill.iorw import papermill_io
@@ -282,8 +281,9 @@ class Notebook(object):
         unattached : bool
             indicator for rendering without making the display recallable as scrapbook data
         """
-        # Avoid circular imports
+        # Avoid circular and make slow imports lazy
         from .api import _prepare_ipy_data_format, _prepare_ipy_display_format
+        from IPython.display import display as ip_display
 
         if name not in self.scraps:
             if raise_on_missing:
@@ -410,6 +410,8 @@ class Scrapbook(collections.MutableMapping):
         header : bool (default: True)
             indicator for if the scraps should render with a header
         """
+        # Keep slow import lazy
+        from IPython.display import display as ip_display, Markdown
 
         def trim_repr(data):
             # Generate a small data representation for display purposes

--- a/scrapbook/models.py
+++ b/scrapbook/models.py
@@ -281,7 +281,7 @@ class Notebook(object):
         unattached : bool
             indicator for rendering without making the display recallable as scrapbook data
         """
-        # Avoid circular and make slow imports lazy
+        # Avoid circular imports and make slow imports lazy
         from .api import _prepare_ipy_data_format, _prepare_ipy_display_format
         from IPython.display import display as ip_display
 

--- a/scrapbook/tests/test_api.py
+++ b/scrapbook/tests/test_api.py
@@ -83,7 +83,7 @@ def kernel_mock():
         ),
     ],
 )
-@mock.patch("scrapbook.api.ip_display")
+@mock.patch("IPython.display.display")
 def test_glue(mock_display, name, scrap, encoder, data, metadata):
     glue(name, scrap, encoder)
     mock_display.assert_called_once_with(data, metadata=metadata, raw=True)
@@ -141,7 +141,7 @@ def test_glue(mock_display, name, scrap, encoder, data, metadata):
         ),
     ],
 )
-@mock.patch("scrapbook.api.ip_display")
+@mock.patch("IPython.display.display")
 def test_glue_display_only(mock_display, name, obj, data, encoder, metadata, display):
     glue(name, obj, encoder, display)
     mock_display.assert_called_once_with(data, metadata=metadata, raw=True)
@@ -186,7 +186,7 @@ def test_glue_display_only(mock_display, name, obj, data, encoder, metadata, dis
         ),
     ],
 )
-@mock.patch("scrapbook.api.ip_display")
+@mock.patch("IPython.display.display")
 def test_glue_plus_display(
     mock_display,
     name,

--- a/scrapbook/tests/test_notebooks.py
+++ b/scrapbook/tests/test_notebooks.py
@@ -158,7 +158,7 @@ def test_record_scraps_collection_dataframe(notebook_backwards_result):
     assert_frame_equal(notebook_backwards_result.scraps.dataframe, expected_df, check_exact=True)
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_reglue_display(mock_display, notebook_result):
     notebook_result.reglue("output")
     mock_display.assert_called_once_with(
@@ -168,7 +168,7 @@ def test_reglue_display(mock_display, notebook_result):
     )
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_reglue_scrap(mock_display, notebook_result):
     notebook_result.reglue("one")
     mock_display.assert_called_once_with(
@@ -185,7 +185,7 @@ def test_reglue_scrap(mock_display, notebook_result):
     )
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_reglue_display_unattached(mock_display, notebook_result):
     notebook_result.reglue("output", unattached=True)
     mock_display.assert_called_once_with(
@@ -193,7 +193,7 @@ def test_reglue_display_unattached(mock_display, notebook_result):
     )
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_reglue_scrap_unattached(mock_display, notebook_result):
     notebook_result.reglue("one", unattached=True)
     mock_display.assert_called_once_with(
@@ -215,7 +215,7 @@ def test_missing_reglue(notebook_result):
         notebook_result.reglue("foo")
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_missing_reglue_no_error(mock_display, notebook_result):
     notebook_result.reglue("foo", raise_on_missing=False)
     mock_display.assert_called_once_with(
@@ -223,7 +223,7 @@ def test_missing_reglue_no_error(mock_display, notebook_result):
     )
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_reglue_rename(mock_display, notebook_result):
     notebook_result.reglue("output", "new_output")
     mock_display.assert_called_once_with(

--- a/scrapbook/tests/test_scrapbooks.py
+++ b/scrapbook/tests/test_scrapbooks.py
@@ -297,7 +297,7 @@ def test_papermill_dataframe(notebook_collection):
     assert_frame_equal(notebook_collection.papermill_dataframe, expected_df)
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_scraps_report(mock_display, notebook_collection):
     notebook_collection.scraps_report()
     mock_display.assert_has_calls(
@@ -317,7 +317,7 @@ def test_scraps_report(mock_display, notebook_collection):
     )
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_scraps_report_no_headers(mock_display, notebook_collection):
     notebook_collection.scraps_report(headers=None)
     mock_display.assert_has_calls(
@@ -330,7 +330,7 @@ def test_scraps_report_no_headers(mock_display, notebook_collection):
     )
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_scraps_report_with_data(mock_display, notebook_collection):
     notebook_collection.scraps_report(include_data=True)
     mock_display.assert_has_calls(
@@ -366,7 +366,7 @@ def test_scraps_report_with_data(mock_display, notebook_collection):
     )
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_scraps_report_with_data_no_headers(mock_display, notebook_collection):
     notebook_collection.scraps_report(headers=None, include_data=True)
     mock_display.assert_has_calls(
@@ -391,7 +391,7 @@ def test_scraps_report_with_data_no_headers(mock_display, notebook_collection):
     )
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_scraps_report_with_scrap_list_names(mock_display, notebook_collection):
     notebook_collection.scraps_report(scrap_names=["output"])
     mock_display.assert_has_calls(
@@ -407,7 +407,7 @@ def test_scraps_report_with_scrap_list_names(mock_display, notebook_collection):
     )
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_scraps_report_with_scrap_string_name(mock_display, notebook_collection):
     notebook_collection.scraps_report(scrap_names="one_only")
     mock_display.assert_has_calls(
@@ -423,7 +423,7 @@ def test_scraps_report_with_scrap_string_name(mock_display, notebook_collection)
     )
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_scraps_report_with_notebook_names(mock_display, notebook_collection):
     notebook_collection.scraps_report(notebook_names="result1")
     mock_display.assert_has_calls(
@@ -437,7 +437,7 @@ def test_scraps_report_with_notebook_names(mock_display, notebook_collection):
     )
 
 
-@mock.patch("scrapbook.models.ip_display")
+@mock.patch("IPython.display.display")
 def test_scraps_report_with_scrap_and_notebook_names(mock_display, notebook_collection):
     notebook_collection.scraps_report(
         scrap_names=["output"], notebook_names=["result1"]


### PR DESCRIPTION
Solves https://github.com/nteract/scrapbook/issues/48

Paired with https://github.com/nteract/papermill/pull/380 this removes IPython from default import paths.