### PR TITLE
Add yaml for Azure pipelines

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -29,3 +29,6 @@ prune docs/_build
 prune binder
 # Scripts
 graft scripts
+# Build files
+prune .tavis.yml
+prune azure-pipelines.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,17 +1,19 @@
 trigger:
-- master
+  - master
 
-variables:
-- group: codecov 
+pr:
+  branches:
+    include:
+      - '*'
 
 jobs:
   - job: 'Test'
 
     pool:
-      vmImage: 'ubuntu-16.04' 
+      vmImage: 'ubuntu-16.04'
     strategy:
       matrix:
-        py27: 
+        py27:
           python.version: '2.7'
           tox.env: py27
         py35:
@@ -23,32 +25,31 @@ jobs:
         py37:
           python.version: '3.7'
           tox.env: py37
-    
+        flake8:
+          python.version: '3.6'
+          tox.env: flake8
+        dist:
+          python.version: '3.6'
+          tox.env: dist
+        docs:
+          python.version: '3.6'
+          tox.env: docs
+        manifest:
+          python.version: '3.6'
+          tox.env: manifest
+
     steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python $(python.version) for tests'
       inputs:
         versionSpec: '$(python.version)'
         architecture: 'x64'
-    
+
+    - script: pip install -U pip
+      displayName: 'Upgrade pip'
+
     - script: pip install tox
       displayName: 'Install tox'
 
     - script: tox -e $(tox.env)
       displayName: 'Run tox -e $(tox.env)'
-
-    - script: |        
-        # run for py36 
-        if [ "$(python.version)" = "3.6" ]; then
-          pip install coverage codecov
-          coverage xml -i
-          codecov
-        fi
-
-      env:
-        CODECOV_TOKEN: $(CODECOV_TOKEN)
-        
-      displayName: 'Report coverage'
-      condition: succeeded()
-
-      

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,36 @@
+trigger:
+- master
+
+jobs:
+  - job: 'Test'
+
+    pool:
+      vmImage: 'ubuntu-16.04' 
+    strategy:
+      matrix:
+        py27: 
+          python.version: '2.7'
+          tox.env: py27
+        py35:
+          python.version: '3.5'
+          tox.env: py35
+        py36:
+          python.version: '3.6'
+          tox.env: py36
+        py37:
+          python.version: '3.7'
+          tox.env: py37
+    
+    steps:
+    - task: UsePythonVersion@0
+      displayName: 'Use Python $(python.version) for tests'
+      inputs:
+        versionSpec: '$(python.version)'
+        architecture: 'x64'
+    
+    - script: pip install tox
+      displayName: 'Install tox'
+
+    - script: tox -e $(tox.env)
+      displayName: 'Run tox -e $(tox.env)'
+      

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,11 +34,10 @@ jobs:
     - script: tox -e $(tox.env)
       displayName: 'Run tox -e $(tox.env)'
 
-    - script: |
-        pip install coverage codecov
-        
+    - script: |        
         # run for py36 
         if [ "$(python.version)" = "3.6" ]; then
+          pip install coverage codecov
           coverage xml -i
           codecov
         fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,4 +33,25 @@ jobs:
 
     - script: tox -e $(tox.env)
       displayName: 'Run tox -e $(tox.env)'
+
+    - script: |
+        if [ ! -f .coverage.* ]; then
+            echo No coverage data found.
+            exit 0
+        fi
+
+        pip install coverage codecov
+
+        # run for py36 
+        if [ "$(python.version)" = "3.6" ]; then
+          coverage xml -i
+          codecov
+        fi
+
+        env:
+          CODECOV_TOKEN: $(codecov.token)
+
+        displayName: 'Report coverage'
+        condition: succeeded()
+
       

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,9 @@
 trigger:
 - master
 
+variables:
+- group: codecov 
+
 jobs:
   - job: 'Test'
 
@@ -43,7 +46,7 @@ jobs:
         fi
 
       env:
-        CODECOV_TOKEN: $(codecov.token)
+        CODECOV_TOKEN: $(CODECOV_TOKEN)
         
       displayName: 'Report coverage'
       condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,23 +35,18 @@ jobs:
       displayName: 'Run tox -e $(tox.env)'
 
     - script: |
-        if [ ! -f .coverage.* ]; then
-            echo No coverage data found.
-            exit 0
-        fi
-
         pip install coverage codecov
-
+        
         # run for py36 
         if [ "$(python.version)" = "3.6" ]; then
           coverage xml -i
           codecov
         fi
 
-        env:
-          CODECOV_TOKEN: $(codecov.token)
-
-        displayName: 'Report coverage'
-        condition: succeeded()
+      env:
+        CODECOV_TOKEN: $(codecov.token)
+        
+      displayName: 'Report coverage'
+      condition: succeeded()
 
       

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -1,4 +1,3 @@
-../scrapbook[dev]
 Sphinx>=1.7
 sphinx_rtd_theme
 recommonmark==0.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ commands = check-manifest
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs
 deps =
+    .[dev]
     -r docs/requirements-doc.txt
 extras = docs
 commands =


### PR DESCRIPTION
## Description

This PR adds `azure-pipelines.yml` which is needed to run the projects CI/CD using Azure pipelines.

Note: The build pipeline still has to be set up for the repository on Azure DevOps.
Note2: The pipeline fails for Python 2.7 but @willingc said it is no longer supported so it might be safe to remove it from the matrix

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (for reference [codecov](https://codecov.io/gh/trallard/scrapbook) and [Azure build](https://dev.azure.com/trallard/scrapbook/_build/results?buildId=102)
- [x] New and existing unit tests pass locally with my changes