### PR TITLE
Pandas glue support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     #   env: TOXENV=docs
     - python: 3.6
       env: TOXENV=manifest
+  allow_failures:
+    - python: 3.8
 install:
   - pip install tox
   - pip install coverage codecov

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,9 +104,7 @@ html_static_path = ["_static"]
 #
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    "**": ["about.html", "navigation.html", "relations.html", "searchbox.html"]
-}
+html_sidebars = {"**": ["about.html", "navigation.html", "relations.html", "searchbox.html"]}
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/docs/reference/scrapbook.rst
+++ b/docs/reference/scrapbook.rst
@@ -6,7 +6,7 @@ Subpackages
 
 .. toctree::
 
-    scrapbook.tests
+   scrapbook.tests
 
 Submodules
 ----------
@@ -15,71 +15,79 @@ scrapbook.api module
 --------------------
 
 .. automodule:: scrapbook.api
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 scrapbook.encoders module
 -------------------------
 
 .. automodule:: scrapbook.encoders
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 scrapbook.exceptions module
 ---------------------------
 
 .. automodule:: scrapbook.exceptions
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 scrapbook.log module
 --------------------
 
 .. automodule:: scrapbook.log
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 scrapbook.models module
 -----------------------
 
 .. automodule:: scrapbook.models
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 scrapbook.schemas module
 ------------------------
 
 .. automodule:: scrapbook.schemas
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 scrapbook.scraps module
 -----------------------
 
 .. automodule:: scrapbook.scraps
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+scrapbook.utils module
+----------------------
+
+.. automodule:: scrapbook.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 scrapbook.version module
 ------------------------
 
 .. automodule:: scrapbook.version
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: scrapbook
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/scrapbook.tests.rst
+++ b/docs/reference/scrapbook.tests.rst
@@ -8,47 +8,55 @@ scrapbook.tests.test\_api module
 --------------------------------
 
 .. automodule:: scrapbook.tests.test_api
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 scrapbook.tests.test\_encoders module
 -------------------------------------
 
 .. automodule:: scrapbook.tests.test_encoders
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 scrapbook.tests.test\_notebooks module
 --------------------------------------
 
 .. automodule:: scrapbook.tests.test_notebooks
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 scrapbook.tests.test\_scrapbooks module
 ---------------------------------------
 
 .. automodule:: scrapbook.tests.test_scrapbooks
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 scrapbook.tests.test\_scraps module
 -----------------------------------
 
 .. automodule:: scrapbook.tests.test_scraps
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+scrapbook.tests.test\_utils module
+----------------------------------
+
+.. automodule:: scrapbook.tests.test_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: scrapbook.tests
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/usage-glue.rst
+++ b/docs/usage-glue.rst
@@ -17,7 +17,7 @@ of the output notebook.
     sb.glue("number", 123)
     sb.glue("some_list", [1, 3, 5])
     sb.glue("some_dict", {"a": 1, "b": 2})
-    sb.glue("non_json", df, 'arrow')
+    sb.glue("non_json", df, 'pandas')
 
 The scrapbook library can be used later to recover scraps (recorded
 values) from the output notebook:
@@ -37,6 +37,17 @@ media type identifying the content encoding format and data. These
 outputs are not always visible in notebook rendering but still exist in
 the document. Scrapbook can then rehydrate the data associated with the
 notebook in the future by reading these cell outputs.
+
+Pandas
+------
+
+When glueing pandas dataframes, the library will use pyarrow to translate
+the dataframe to a base64 encoded parquet file. Because of this tool chain,
+certain nested objects will not encode cleanly and will raise an Arrow
+exception. Common nested objects that will fail include columns with dicts
+or sets within them, either directly or nested inside other objects. Over
+time these nested types should be more supported (nested lists work for
+example) as Arrow adds struct transformations.
 
 Display Outputs
 ---------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pandas
-six
 papermill
 jsonschema
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 papermill
 jsonschema
 ipython
+pyarrow

--- a/scrapbook/api.py
+++ b/scrapbook/api.py
@@ -5,7 +5,6 @@ api.py
 Provides the base API calls for scrapbook
 """
 import os
-import pandas as pd
 
 # We lean on papermill's readers to connect to remote stores
 from papermill.iorw import list_notebook_files
@@ -17,30 +16,12 @@ from .encoders import registry as encoder_registry
 from .utils import kernel_required
 
 
-def determine_encoder(scrap):
-    # Keep slow import lazy
-    import IPython
-    from IPython.display import DisplayObject
-
-    if isinstance(scrap, str):
-        return "text"
-    elif isinstance(scrap, (list, dict)):
-        return "json"
-    elif isinstance(scrap, DisplayObject):
-        return "display"
-    elif isinstance(scrap, pd.DataFrame):
-        return "pandas"
-    else:
-        # This may be more complex in the future
-        return "json"
-
-
 @kernel_required
-def glue(name, scrap, encoder=None, display=None):
+def glue(name, data, encoder=None, display=None):
     """
-    Records a scrap (data value) in the given notebook cell.
+    Records a data value in the given notebook cell.
 
-    The scrap (recorded value) can be retrieved during later inspection of the
+    The recorded data value can be retrieved during later inspection of the
     output notebook.
 
     The data type of the scraps is implied by the value type of any of the
@@ -72,8 +53,9 @@ def glue(name, scrap, encoder=None, display=None):
     ----------
     name: str
         Name of the value to record.
-    scrap: any
-        The value to record.
+    data: any
+        The value to record. This must be an object for which an encoder's
+        `encodable` method returns True.
     encoder: str (optional)
         The name of the handler to use in persisting data in the notebook.
     display: any (optional)
@@ -84,24 +66,18 @@ def glue(name, scrap, encoder=None, display=None):
     from IPython.display import display as ip_display
 
     # TODO: Implement the cool stuff. Remote storage indicators?!? Maybe remote media type?!?
-    # TODO: Make this more modular
-    # TODO: Use translators to determine best storage type
-    # ...
     if not encoder:
-        encoder = determine_encoder(scrap)
+        encoder = encoder_registry.determine_encoder_name(data)
 
-    # TODO: default to 'display' encoder when encoder is None and object is a display object type?
     if display is None:
         display = encoder == "display"
 
     # Only store data that can be stored (purely display scraps can skip)
     if encoder != "display":
-        data, metadata = _prepare_ipy_data_format(
-            name,
-            scrap_to_payload(encoder_registry.encode(Scrap(name, scrap, encoder))),
-            encoder,
+        ipy_data, metadata = _prepare_ipy_data_format(
+            name, scrap_to_payload(encoder_registry.encode(Scrap(name, data, encoder))), encoder
         )
-        ip_display(data, metadata=metadata, raw=True)
+        ip_display(ipy_data, metadata=metadata, raw=True)
 
     # Only display data that is marked for display
     if display:
@@ -110,9 +86,7 @@ def glue(name, scrap, encoder=None, display=None):
             display_kwargs = {"include": display}
         elif isinstance(display, dict):
             display_kwargs = display
-        raw_data, raw_metadata = IPython.core.formatters.format_display_data(
-            scrap, **display_kwargs
-        )
+        raw_data, raw_metadata = IPython.core.formatters.format_display_data(data, **display_kwargs)
         data, metadata = _prepare_ipy_display_format(name, raw_data, raw_metadata)
         ip_display(data, metadata=metadata, raw=True)
 

--- a/scrapbook/exceptions.py
+++ b/scrapbook/exceptions.py
@@ -9,6 +9,10 @@ class ScrapbookMissingEncoder(ScrapbookException):
     """Raised when no encoder is found to tranforming data"""
 
 
+class ScrapbookInvalidEncoder(ScrapbookException):
+    """Raised when no encoder is found to tranforming data"""
+
+
 class ScrapbookDataException(ScrapbookException):
     """Raised when a data translation exception is encountered"""
 

--- a/scrapbook/models.py
+++ b/scrapbook/models.py
@@ -55,9 +55,7 @@ class Notebook(object):
             path = urlparse(node_or_path).path
             if not os.path.splitext(path)[-1].endswith('ipynb'):
                 raise Warning(
-                    "Requires an '.ipynb' file extension. Provided path: '{}'".format(
-                        node_or_path
-                    )
+                    "Requires an '.ipynb' file extension. Provided path: '{}'".format(node_or_path)
                 )
             self.path = node_or_path
             self.node = nbformat.reads(papermill_io.read(node_or_path), as_version=4)
@@ -254,9 +252,7 @@ class Notebook(object):
     def papermill_dataframe(self):
         """pandas dataframe: dataframe of notebook parameters and cell scraps"""
         # Meant for backwards compatibility to papermill's dataframe method
-        return self.parameter_dataframe.append(
-            self.papermill_record_dataframe, ignore_index=True
-        )
+        return self.parameter_dataframe.append(self.papermill_record_dataframe, ignore_index=True)
 
     def _strip_scrapbook_metadata(self, metadata):
         copied = copy.copy(metadata)
@@ -291,9 +287,7 @@ class Notebook(object):
                     "Scrap '{}' is not available in this notebook.".format(name)
                 )
             else:
-                ip_display(
-                    "No scrap found with name '{}' in this notebook".format(name)
-                )
+                ip_display("No scrap found with name '{}' in this notebook".format(name))
         else:
             scrap = self.scraps[name]
             if new_name:
@@ -309,12 +303,8 @@ class Notebook(object):
                 ip_display(data, metadata=metadata, raw=True)
             if scrap.display is not None:
                 scrap_data = scrap.display.get("data", {})
-                scrap_metadata = self._strip_scrapbook_metadata(
-                    scrap.display.get("metadata", {})
-                )
-                data, metadata = _prepare_ipy_display_format(
-                    scrap.name, scrap_data, scrap_metadata
-                )
+                scrap_metadata = self._strip_scrapbook_metadata(scrap.display.get("metadata", {}))
+                data, metadata = _prepare_ipy_display_format(scrap.name, scrap_data, scrap_metadata)
                 if unattached:
                     # Remove 'scrapbook' from keys if we want it unassociated
                     metadata = self._strip_scrapbook_metadata(metadata)
@@ -449,6 +439,4 @@ class Scrapbook(collections.MutableMapping):
                             ip_display(Markdown("#### {}".format(name)))
                             ip_display(trim_repr(scrap.data))
                         else:
-                            ip_display(
-                                "{}: {}".format(scrap.name, trim_repr(scrap.data))
-                            )
+                            ip_display("{}: {}".format(scrap.name, trim_repr(scrap.data)))

--- a/scrapbook/schemas.py
+++ b/scrapbook/schemas.py
@@ -21,12 +21,8 @@ RECORD_PAYLOAD_PREFIX = "application/papermill.record"
 JSON_FILE_VERSION_REGEX = r".*scrap\.v([0-9]+)\.json"
 SCHEMAS = {
     int(re.search(JSON_FILE_VERSION_REGEX, fname).group(1)): _load_schema(fname)
-    for fname in glob.glob(
-        os.path.join(os.path.dirname(__file__), "schemas/scrap.v*.json")
-    )
-    if re.match(
-        JSON_FILE_VERSION_REGEX, fname
-    )  # Since glob can't perfectly match the regex
+    for fname in glob.glob(os.path.join(os.path.dirname(__file__), "schemas/scrap.v*.json"))
+    if re.match(JSON_FILE_VERSION_REGEX, fname)  # Since glob can't perfectly match the regex
 }
 # Update for any new json payloads and schemas/scrap.v*.json
 LATEST_SCRAP_VERSION = 1

--- a/scrapbook/scraps.py
+++ b/scrapbook/scraps.py
@@ -45,9 +45,7 @@ def payload_to_scrap(payload):
     if "version" not in payload:
         raise ScrapbookDataException(
             "Scrap payload (name={}) has no version indicator. "
-            "This scrap is invalid and cannot be loaded".format(
-                payload.get("name", "None")
-            )
+            "This scrap is invalid and cannot be loaded".format(payload.get("name", "None"))
         )
     if payload["version"] > LATEST_SCRAP_VERSION:
         logger.warning(
@@ -63,18 +61,12 @@ def payload_to_scrap(payload):
         except ValidationError as e:
             raise ScrapbookDataException(
                 "Scrap payload (name={name}) contents do not conform to required "
-                "type structures: {error}".format(
-                    name=payload.get("name", "None"), error=str(e)
-                ),
+                "type structures: {error}".format(name=payload.get("name", "None"), error=str(e)),
                 [e],
             )
     # If future schema versions would require further manipulation
     # then implement various version loaders here
-    return Scrap(
-        name=payload.get("name"),
-        data=payload.get("data"),
-        encoder=payload.get("encoder"),
-    )
+    return Scrap(name=payload.get("name"), data=payload.get("data"), encoder=payload.get("encoder"))
 
 
 class Scraps(OrderedDict):
@@ -101,9 +93,6 @@ class Scraps(OrderedDict):
     def dataframe(self):
         """pandas dataframe: dataframe of cell scraps"""
         return pd.DataFrame(
-            [
-                [scrap.name, scrap.data, scrap.encoder, scrap.display]
-                for scrap in self.values()
-            ],
+            [[scrap.name, scrap.data, scrap.encoder, scrap.display] for scrap in self.values()],
             columns=["name", "data", "encoder", "display"],
         )

--- a/scrapbook/tests/test_api.py
+++ b/scrapbook/tests/test_api.py
@@ -4,13 +4,12 @@ import six
 import mock
 import pytest
 import collections
-import pandas as pd
 
 from IPython.display import Image
 
 from . import get_fixture_path
 from .. import utils
-from ..api import glue, determine_encoder
+from ..api import glue
 from ..schemas import GLUE_PAYLOAD_FMT
 
 
@@ -213,38 +212,3 @@ def test_glue_warning(kernel_mock):
     kernel_mock.return_value = False
     with pytest.warns(UserWarning):
         glue('foo', 'bar', 'text')
-
-
-@pytest.mark.parametrize(
-    "scrap,expected_encoder",
-    [
-        (
-            "foo,bar,baz",
-            "text"
-        ),
-        (
-            Image(filename=get_fixture_path("tiny.png")),
-            "display"
-        ),
-        (
-            ['foo', 'bar'],
-            "json"
-        ),
-        (
-            {'foo': 'bar'},
-            "json"
-        ),
-        (
-            pd.DataFrame(data=
-                {"foo": pd.Series(["bar"], dtype='str')}),
-            "pandas"
-        ),
-        # Falls back to json for anything else
-        (
-            mock.Mock(),
-            "json"
-        ),
-    ],
-)
-def test_determine_encoder(scrap, expected_encoder):
-    assert determine_encoder(scrap) == expected_encoder

--- a/scrapbook/tests/test_encoders.py
+++ b/scrapbook/tests/test_encoders.py
@@ -2,21 +2,23 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-import base64
+import mock
 import pyarrow
 import pandas as pd
 
-from io import BytesIO
+from IPython.display import Image
 
+from . import get_fixture_path
 from ..encoders import (
+    registry as full_registry,
     DataEncoderRegistry,
     JsonEncoder,
     TextEncoder,
     PandasArrowDataframeEncoder,
 )
 from ..exceptions import (
-    ScrapbookException,
     ScrapbookDataException,
+    ScrapbookInvalidEncoder,
     ScrapbookMissingEncoder,
 )
 from ..scraps import Scrap
@@ -139,10 +141,7 @@ class Dummy(object):
             Scrap(name="foo", data=Dummy(), encoder="text"),
             Scrap(name="foo", data="foo", encoder="text"),
         ),
-        (
-            Scrap(name="foo", data="😍", encoder="text"),
-            Scrap(name="foo", data="😍", encoder="text"),
-        ),
+        (Scrap(name="foo", data="😍", encoder="text"), Scrap(name="foo", data="😍", encoder="text")),
     ],
 )
 def test_text_decode(test_input, expected):
@@ -172,10 +171,7 @@ def test_text_decode(test_input, expected):
             Scrap(name="foo", data=Dummy(), encoder="text"),
             Scrap(name="foo", data="foo", encoder="text"),
         ),
-        (
-            Scrap(name="foo", data="😍", encoder="text"),
-            Scrap(name="foo", data="😍", encoder="text"),
-        ),
+        (Scrap(name="foo", data="😍", encoder="text"), Scrap(name="foo", data="😍", encoder="text")),
     ],
 )
 def test_text_encode(test_input, expected):
@@ -186,29 +182,44 @@ def test_text_encode(test_input, expected):
     "test_input",
     [
         (
-            Scrap(name="foo", data=pd.DataFrame(data=
-                {"foo": pd.Series(["bar"], dtype='str'), "baz": pd.Series([1], dtype='int')}),
-                encoder="pandas")
+            Scrap(
+                name="foo",
+                data=pd.DataFrame(
+                    data={
+                        "foo": pd.Series(["bar"], dtype='str'),
+                        "baz": pd.Series([1], dtype='int'),
+                    }
+                ),
+                encoder="pandas",
+            )
         ),
         (
-            Scrap(name="foo", data=pd.DataFrame(
-                data={
-                    "foo": pd.Series(["😍", "emoji"], dtype='str'),
-                    "baz": pd.Series(["no", "unicode"], dtype='str')
-                }),
-                encoder="pandas")
+            Scrap(
+                name="foo",
+                data=pd.DataFrame(
+                    data={
+                        "foo": pd.Series(["😍", "emoji"], dtype='str'),
+                        "baz": pd.Series(["no", "unicode"], dtype='str'),
+                    }
+                ),
+                encoder="pandas",
+            )
         ),
         # Nested lists of lists of strings are ok
         (
-            Scrap(name="foo", data=pd.DataFrame(data=
-                {"foo": pd.Series([[["foo", "bar"]]], dtype='object')}),
-                encoder="pandas")
+            Scrap(
+                name="foo",
+                data=pd.DataFrame(data={"foo": pd.Series([[["foo", "bar"]]], dtype='object')}),
+                encoder="pandas",
+            )
         ),
         # String objects are ok
         (
-            Scrap(name="foo", data=pd.DataFrame(data=
-                {"foo": pd.Series(["bar"], dtype='object')}),
-                encoder="pandas")
+            Scrap(
+                name="foo",
+                data=pd.DataFrame(data={"foo": pd.Series(["bar"], dtype='object')}),
+                encoder="pandas",
+            )
         ),
     ],
 )
@@ -227,17 +238,21 @@ def test_pandas_encode_and_decode(test_input):
     [
         # Dicts can't convert
         (
-            Scrap(name="foo", data=pd.DataFrame(data=
-                {"foo": pd.Series([{"foo": "bar"}], dtype='object')}),
-                encoder="pandas"),
-            pyarrow.lib.ArrowNotImplementedError
+            Scrap(
+                name="foo",
+                data=pd.DataFrame(data={"foo": pd.Series([{"foo": "bar"}], dtype='object')}),
+                encoder="pandas",
+            ),
+            pyarrow.lib.ArrowNotImplementedError,
         ),
         # Sets can't convert
         (
-            Scrap(name="foo", data=pd.DataFrame(data=
-                {"foo": pd.Series([{"foo", "bar"}], dtype='object')}),
-                encoder="pandas"),
-            pyarrow.lib.ArrowInvalid
+            Scrap(
+                name="foo",
+                data=pd.DataFrame(data={"foo": pd.Series([{"foo", "bar"}], dtype='object')}),
+                encoder="pandas",
+            ),
+            pyarrow.lib.ArrowInvalid,
         ),
     ],
 )
@@ -249,22 +264,27 @@ def test_unsupported_arrow_conversions(test_input, exception_type):
 @pytest.fixture
 def registry():
     registry = DataEncoderRegistry()
-    registry.register("json", JsonEncoder())
+    registry.register(JsonEncoder())
     return registry
 
 
 def test_registry_register(registry):
-    registry.register("text", TextEncoder())
+    registry.register(TextEncoder())
     assert "text" in registry
 
 
 def test_registry_invalid_register(registry):
-    with pytest.raises(ScrapbookException):
-        registry.register("text", "not an encoder")
+    with pytest.raises(ScrapbookInvalidEncoder):
+        registry.register("not an encoder")
 
 
 def test_registry_deregister(registry):
     registry.deregister("json")
+    assert "json" not in registry
+
+
+def test_registry_deregister(registry):
+    registry.deregister(JsonEncoder())
     assert "json" not in registry
 
 
@@ -274,7 +294,7 @@ def test_registry_missing_deregister(registry):
 
 
 def test_registry_reset(registry):
-    registry.register("text", TextEncoder())
+    registry.register(TextEncoder())
     registry.reset()
     assert "json" not in registry
     assert "text" not in registry
@@ -283,16 +303,16 @@ def test_registry_reset(registry):
 
 def test_decode(registry):
     # Test that it can select and execute the qualified encoder
-    assert registry.decode(
-        Scrap(name="foo", encoder="json", data='["foobar"]')
-    ) == Scrap(name="foo", encoder="json", data=["foobar"])
+    assert registry.decode(Scrap(name="foo", encoder="json", data='["foobar"]')) == Scrap(
+        name="foo", encoder="json", data=["foobar"]
+    )
 
 
 def test_encode(registry):
     # Test that it can select and execute the qualified encoder
-    assert registry.encode(
-        Scrap(name="foo", encoder="json", data='["foobar"]')
-    ) == Scrap(name="foo", encoder="json", data=["foobar"])
+    assert registry.encode(Scrap(name="foo", encoder="json", data='["foobar"]')) == Scrap(
+        name="foo", encoder="json", data=["foobar"]
+    )
 
 
 class BadData(object):
@@ -300,6 +320,9 @@ class BadData(object):
 
 
 class BadEncoder(object):
+    def name(self):
+        return "bad"
+
     def decode(self, scrap, **kwargs):
         return Scrap(scrap.name, data=BadData(), encoder="bad")
 
@@ -308,13 +331,13 @@ class BadEncoder(object):
 
 
 def test_bad_decode(registry):
-    registry.register("bad", BadEncoder())
+    registry.register(BadEncoder())
     with pytest.raises(ScrapbookDataException):
         registry.decode(Scrap(name="foo", data=BadData(), encoder="bad"))
 
 
 def test_bad_encode(registry):
-    registry.register("bad", BadEncoder())
+    registry.register(BadEncoder())
     with pytest.raises(ScrapbookDataException):
         registry.encode(Scrap(name="foo", data="", encoder="bad"))
 
@@ -327,3 +350,23 @@ def test_missing_decode(registry):
 def test_missing_encode(registry):
     with pytest.raises(ScrapbookMissingEncoder):
         registry.encode(Scrap(name="foo", data="bar", encoder="missing"))
+
+
+@pytest.mark.parametrize(
+    "data,expected_encoder",
+    [
+        ("foo,bar,baz", "text"),
+        (Image(filename=get_fixture_path("tiny.png")), "display"),
+        (['foo', 'bar'], "json"),
+        ({'foo': 'bar'}, "json"),
+        (pd.DataFrame(data={"foo": pd.Series(["bar"], dtype='str')}), "pandas"),
+    ],
+)
+def test_determine_encoder_name(data, expected_encoder):
+    assert full_registry.determine_encoder_name(data) == expected_encoder
+
+
+@pytest.mark.parametrize("data", [mock.Mock(), object(), TextEncoder()])
+def test_determine_encoder_name_fails(data):
+    with pytest.raises(NotImplementedError):
+        full_registry.determine_encoder_name(data)

--- a/scrapbook/tests/test_notebooks.py
+++ b/scrapbook/tests/test_notebooks.py
@@ -58,13 +58,9 @@ def test_bad_ext():
 @mock.patch("papermill.iorw.papermill_io.read")
 def test_good_ext_for_url(mock_read):
     sample_output = {
-        "cells": [{
-            "cell_type": "code",
-            "execution_count": 1,
-            "metadata": {},
-            "outputs": [],
-            "source": []
-        }]
+        "cells": [
+            {"cell_type": "code", "execution_count": 1, "metadata": {}, "outputs": [], "source": []}
+        ]
     }
 
     mock_read.return_value = json.dumps(sample_output)
@@ -109,20 +105,12 @@ def test_display_scraps(notebook_result):
     assert notebook_result.scraps.display_dict == {
         "output": {
             "data": {"text/plain": "'Hello World!'"},
-            "metadata": {
-                "scrapbook": {
-                    "name": "output",
-                    "data": False,
-                    "display": True,
-                }
-            },
+            "metadata": {"scrapbook": {"name": "output", "data": False, "display": True}},
             "output_type": "display_data",
         },
         "one_only": {
             "data": {"text/plain": "'Just here!'"},
-            "metadata": {
-                "scrapbook": {"name": "one_only", "data": False, "display": True}
-            },
+            "metadata": {"scrapbook": {"name": "one_only", "data": False, "display": True}},
             "output_type": "display_data",
         },
     }
@@ -188,9 +176,7 @@ def test_reglue_scrap(mock_display, notebook_result):
 @mock.patch("IPython.display.display")
 def test_reglue_display_unattached(mock_display, notebook_result):
     notebook_result.reglue("output", unattached=True)
-    mock_display.assert_called_once_with(
-        {"text/plain": "'Hello World!'"}, metadata={}, raw=True
-    )
+    mock_display.assert_called_once_with({"text/plain": "'Hello World!'"}, metadata={}, raw=True)
 
 
 @mock.patch("IPython.display.display")
@@ -218,9 +204,7 @@ def test_missing_reglue(notebook_result):
 @mock.patch("IPython.display.display")
 def test_missing_reglue_no_error(mock_display, notebook_result):
     notebook_result.reglue("foo", raise_on_missing=False)
-    mock_display.assert_called_once_with(
-        "No scrap found with name 'foo' in this notebook"
-    )
+    mock_display.assert_called_once_with("No scrap found with name 'foo' in this notebook")
 
 
 @mock.patch("IPython.display.display")

--- a/scrapbook/tests/test_scrapbooks.py
+++ b/scrapbook/tests/test_scrapbooks.py
@@ -37,9 +37,7 @@ def notebook_collection():
 
 
 def test_assign_from_path(notebook_collection):
-    notebook_collection["result_no_exec.ipynb"] = get_notebook_path(
-        "result_no_exec.ipynb"
-    )
+    notebook_collection["result_no_exec.ipynb"] = get_notebook_path("result_no_exec.ipynb")
 
 
 def test_notebook_scraps(notebook_collection):
@@ -49,31 +47,12 @@ def test_notebook_scraps(notebook_collection):
                 "result1",
                 Scraps(
                     [
-                        (
-                            "one",
-                            Scrap(name="one", data=1, encoder="json", display=None),
-                        ),
-                        (
-                            "number",
-                            Scrap(name="number", data=1, encoder="json", display=None),
-                        ),
-                        (
-                            "list",
-                            Scrap(
-                                name="list",
-                                data=[1, 2, 3],
-                                encoder="json",
-                                display=None,
-                            ),
-                        ),
+                        ("one", Scrap(name="one", data=1, encoder="json", display=None)),
+                        ("number", Scrap(name="number", data=1, encoder="json", display=None)),
+                        ("list", Scrap(name="list", data=[1, 2, 3], encoder="json", display=None)),
                         (
                             "dict",
-                            Scrap(
-                                name="dict",
-                                data={"a": 1, "b": 2},
-                                encoder="json",
-                                display=None,
-                            ),
+                            Scrap(name="dict", data={"a": 1, "b": 2}, encoder="json", display=None),
                         ),
                         (
                             "output",
@@ -120,31 +99,12 @@ def test_notebook_scraps(notebook_collection):
                 "result2",
                 Scraps(
                     [
-                        (
-                            "two",
-                            Scrap(name="two", data=2, encoder="json", display=None),
-                        ),
-                        (
-                            "number",
-                            Scrap(name="number", data=2, encoder="json", display=None),
-                        ),
-                        (
-                            "list",
-                            Scrap(
-                                name="list",
-                                data=[4, 5, 6],
-                                encoder="json",
-                                display=None,
-                            ),
-                        ),
+                        ("two", Scrap(name="two", data=2, encoder="json", display=None)),
+                        ("number", Scrap(name="number", data=2, encoder="json", display=None)),
+                        ("list", Scrap(name="list", data=[4, 5, 6], encoder="json", display=None)),
                         (
                             "dict",
-                            Scrap(
-                                name="dict",
-                                data={"a": 3, "b": 4},
-                                encoder="json",
-                                display=None,
-                            ),
+                            Scrap(name="dict", data={"a": 3, "b": 4}, encoder="json", display=None),
                         ),
                         (
                             "output",
@@ -197,10 +157,7 @@ def test_scraps(notebook_collection):
             ("one", Scrap(name="one", data=1, encoder="json", display=None)),
             ("number", Scrap(name="number", data=2, encoder="json", display=None)),
             ("list", Scrap(name="list", data=[4, 5, 6], encoder="json", display=None)),
-            (
-                "dict",
-                Scrap(name="dict", data={"a": 3, "b": 4}, encoder="json", display=None),
-            ),
+            ("dict", Scrap(name="dict", data={"a": 3, "b": 4}, encoder="json", display=None)),
             (
                 "output",
                 Scrap(
@@ -210,11 +167,7 @@ def test_scraps(notebook_collection):
                     display={
                         "data": {"text/plain": "'Hello World 2!'"},
                         "metadata": {
-                            "scrapbook": {
-                                "data": False,
-                                "display": True,
-                                "name": "output",
-                            }
+                            "scrapbook": {"data": False, "display": True, "name": "output"}
                         },
                         "output_type": "display_data",
                     },
@@ -229,11 +182,7 @@ def test_scraps(notebook_collection):
                     display={
                         "data": {"text/plain": "'Just here!'"},
                         "metadata": {
-                            "scrapbook": {
-                                "data": False,
-                                "display": True,
-                                "name": "one_only",
-                            }
+                            "scrapbook": {"data": False, "display": True, "name": "one_only"}
                         },
                         "output_type": "display_data",
                     },
@@ -249,11 +198,7 @@ def test_scraps(notebook_collection):
                     display={
                         "data": {"text/plain": "'Just here!'"},
                         "metadata": {
-                            "scrapbook": {
-                                "data": False,
-                                "display": True,
-                                "name": "two_only",
-                            }
+                            "scrapbook": {"data": False, "display": True, "name": "two_only"}
                         },
                         "output_type": "display_data",
                     },
@@ -376,17 +321,13 @@ def test_scraps_report_with_data_no_headers(mock_display, notebook_collection):
             mock.call("one: 1"),
             mock.call("number: 1"),
             mock.call("list: [1, 2, 3]"),
-            mock.call(
-                "dict: {'a': 1, 'b': 2}" if six.PY3 else "dict: {u'a': 1, u'b': 2}"
-            ),
+            mock.call("dict: {'a': 1, 'b': 2}" if six.PY3 else "dict: {u'a': 1, u'b': 2}"),
             mock.call({"text/plain": "'Hello World 2!'"}, metadata={}, raw=True),
             mock.call({"text/plain": "'Just here!'"}, metadata={}, raw=True),
             mock.call("two: 2"),
             mock.call("number: 2"),
             mock.call("list: [4, 5, 6]"),
-            mock.call(
-                "dict: {'a': 3, 'b': 4}" if six.PY3 else "dict: {u'a': 3, u'b': 4}"
-            ),
+            mock.call("dict: {'a': 3, 'b': 4}" if six.PY3 else "dict: {u'a': 3, u'b': 4}"),
         ]
     )
 
@@ -439,9 +380,7 @@ def test_scraps_report_with_notebook_names(mock_display, notebook_collection):
 
 @mock.patch("IPython.display.display")
 def test_scraps_report_with_scrap_and_notebook_names(mock_display, notebook_collection):
-    notebook_collection.scraps_report(
-        scrap_names=["output"], notebook_names=["result1"]
-    )
+    notebook_collection.scraps_report(scrap_names=["output"], notebook_names=["result1"])
     mock_display.assert_has_calls(
         [
             mock.call(AnyMarkdownWith("### result1")),

--- a/scrapbook/tests/test_scraps.py
+++ b/scrapbook/tests/test_scraps.py
@@ -40,12 +40,7 @@ from ..exceptions import ScrapbookDataException
         ),
         (
             Scrap(name="foo", data=["😍"], encoder="json"),
-            {
-                "name": "foo",
-                "data": ["😍"],
-                "encoder": "json",
-                "version": LATEST_SCRAP_VERSION,
-            },
+            {"name": "foo", "data": ["😍"], "encoder": "json", "version": LATEST_SCRAP_VERSION},
         ),
     ],
 )
@@ -84,12 +79,7 @@ def test_scrap_to_payload(test_input, expected):
             Scrap(name="foo", data=["foo", "bar", 1, 2, 3], encoder="json"),
         ),
         (
-            {
-                "name": "foo",
-                "data": ["😍"],
-                "encoder": "json",
-                "version": LATEST_SCRAP_VERSION,
-            },
+            {"name": "foo", "data": ["😍"], "encoder": "json", "version": LATEST_SCRAP_VERSION},
             Scrap(name="foo", data=["😍"], encoder="json"),
         ),
     ],
@@ -125,12 +115,7 @@ def test_scrap_to_payload_validation_error(test_input):
             "encoder": None,
             "version": LATEST_SCRAP_VERSION,
         },
-        {
-            "name": "foo",
-            "data": None,
-            "encoder": "json",
-            "version": LATEST_SCRAP_VERSION,
-        },
+        {"name": "foo", "data": None, "encoder": "json", "version": LATEST_SCRAP_VERSION},
         {
             "name": None,
             "data": ["foo", "bar", 1, 2, 3],

--- a/scrapbook/tests/test_utils.py
+++ b/scrapbook/tests/test_utils.py
@@ -7,8 +7,9 @@ from ..utils import is_kernel
 
 
 def test_is_kernel_true():
-    class FakeIPyKernel():
+    class FakeIPyKernel:
         kernel = True
+
     sys.modules['IPython'] = MagicMock()
     sys.modules['IPython'].get_ipython.return_value = FakeIPyKernel
     assert is_kernel()

--- a/scrapbook/utils.py
+++ b/scrapbook/utils.py
@@ -37,7 +37,9 @@ def deprecated(version, replacement=None):
                 stacklevel=2,
             )
             return func(*args, **kwargs)
+
         return new_func
+
     return wrapper
 
 
@@ -48,6 +50,7 @@ def is_kernel():
     # if IPython hasn't been imported, there's nothing to check
     if 'IPython' in sys.modules:
         from IPython import get_ipython
+
         ipy = get_ipython()
         if ipy is not None:
             return getattr(ipy, 'kernel', None) is not None
@@ -58,8 +61,7 @@ def kernel_required(f):
     @wraps(f)
     def wrapper(*args, **kwds):
         if not is_kernel():
-            warnings.warn(
-                "No kernel detected for '{fname}'.".format(
-                    fname=f.__name__))
+            warnings.warn("No kernel detected for '{fname}'.".format(fname=f.__name__))
         return f(*args, **kwds)
+
     return wrapper

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/nteract/scrapbook",
     packages=["scrapbook"],
-    python_requires = '>=3.5',
+    python_requires='>=3.5',
     include_package_data=True,
     install_requires=read_reqs("requirements.txt"),
     extras_require=extras_require,


### PR DESCRIPTION
This PR pulled pandas support from https://github.com/nteract/scrapbook/pull/37 and purely adds that transformation logic. Now calling `glue` on a pandas dataframe will encode it in base64 parquet text in the notebook. The S3 storage support will come in a later PR.

There are some limitations imposed on custom python types that can be nested within a dataframe by PyArrow. I tried to add some notes to the documentation about this limitation.