### PR TITLE
Fixing custom encoder code snippet

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -75,7 +75,7 @@ simply call:
 
 .. code:: python
 
-    from encoder import registry as encoder_registry
+    from scrapbook.encoders import registry as encoder_registry
     # add encoder to the registry
     encoder_registry.register("custom_encoder_name", MyCustomEncoder())
 


### PR DESCRIPTION
Was trying to use this code snippet on my own project. Could not find an `encoder` symbol in `scrapbook`. Probably was meant to say `encoders`.