### PR TITLE
Added fallback for only setting display=True but not encoder=display

### DIFF
--- a/scrapbook/api.py
+++ b/scrapbook/api.py
@@ -71,7 +71,8 @@ def glue(name, data, encoder=None, display=None):
             encoder = encoder_registry.determine_encoder_name(data)
         except NotImplementedError:
             if display is not None:
-                # The scrap isn't encodable, but the display object it might be, so don't raise
+                # Do not raise an exception if the scrap isn't encodable because
+                # the corresponding display object may be.
                 encoder = 'display'
             else:
                 raise

--- a/scrapbook/api.py
+++ b/scrapbook/api.py
@@ -67,7 +67,14 @@ def glue(name, data, encoder=None, display=None):
 
     # TODO: Implement the cool stuff. Remote storage indicators?!? Maybe remote media type?!?
     if not encoder:
-        encoder = encoder_registry.determine_encoder_name(data)
+        try:
+            encoder = encoder_registry.determine_encoder_name(data)
+        except NotImplementedError:
+            if display is not None:
+                # The scrap isn't encodable, but the display object it might be, so don't raise
+                encoder = 'display'
+            else:
+                raise
 
     if display is None:
         display = encoder == "display"

--- a/scrapbook/tests/test_api.py
+++ b/scrapbook/tests/test_api.py
@@ -148,6 +148,67 @@ def test_glue_display_only(mock_display, name, obj, data, encoder, metadata, dis
 
 
 @pytest.mark.parametrize(
+    "name,obj,data,encoder,metadata,display",
+    [
+        (
+            "foobarbaz",
+            "foo,bar,baz",
+            {"text/plain": "'foo,bar,baz'"},
+            None,
+            {"scrapbook": {"name": "foobarbaz", "data": False, "display": True}},
+            True,
+        ),
+        (
+            "tinypng",
+            Image(filename=get_fixture_path("tiny.png")),
+            {
+                "image/png": (
+                    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gwRBREo2qqE0wAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAFklEQVQI12P8//8/AwMDEwMDAwMDAwAkBgMBvR7jugAAAABJRU5ErkJggg==\n"  # noqa: E501
+                    if six.PY3
+                    else "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x02\x00\x00\x00\x02\x08\x02\x00\x00\x00\xfd\xd4\x9as\x00\x00\x00\tpHYs\x00\x00\x0b\x13\x00\x00\x0b\x13\x01\x00\x9a\x9c\x18\x00\x00\x00\x07tIME\x07\xe2\x0c\x11\x05\x11(\xda\xaa\x84\xd3\x00\x00\x00\x1diTXtComment\x00\x00\x00\x00\x00Created with GIMPd.e\x07\x00\x00\x00\x16IDAT\x08\xd7c\xfc\xff\xff?\x03\x03\x03\x13\x03\x03\x03\x03\x03\x03\x00$\x06\x03\x01\xbd\x1e\xe3\xba\x00\x00\x00\x00IEND\xaeB`\x82"  # noqa: E501
+                ),
+                "text/plain": "<IPython.core.display.Image object>",
+            },
+            None,
+            {"scrapbook": {"name": "tinypng", "data": False, "display": True}},
+            True,
+        ),
+        (
+            "tinypng",
+            Image(filename=get_fixture_path("tiny.png")),
+            {"text/plain": "<IPython.core.display.Image object>"},
+            None,
+            {"scrapbook": {"name": "tinypng", "data": False, "display": True}},
+            ("text/plain",),  # Pick content of display
+        ),
+        (
+            "tinypng",
+            Image(filename=get_fixture_path("tiny.png")),
+            {"text/plain": "<IPython.core.display.Image object>"},
+            None,
+            {"scrapbook": {"name": "tinypng", "data": False, "display": True}},
+            {"exclude": "image/png"},  # Exclude content of display
+        ),
+        (
+            "tinypng",
+            Image(filename=get_fixture_path("tiny.png")),
+            {},  # Should have no matching outputs
+            None,
+            {"scrapbook": {"name": "tinypng", "data": False, "display": True}},
+            ("n/a",),  # Pick content of display
+        ),
+    ],
+)
+@mock.patch("IPython.display.display")
+@mock.patch('scrapbook.api.encoder_registry')
+def test_glue_display_encoder_fallback(
+        mock_registry, mock_display, name, obj, data, encoder, metadata, display):
+    mock_registry.determine_encoder_name.side_effect = mock.Mock(side_effect=NotImplementedError('N/A'))
+    glue(name, obj, encoder, display)
+    mock_display.assert_called_once_with(data, metadata=metadata, raw=True)
+
+
+@pytest.mark.parametrize(
     "name,obj,data_output,display_output,encoder,data_metadata,display_metadata,display",
     [
         (


### PR DESCRIPTION
Noticed that setting display=True without an encoder was failing rather than intuitively picking the display encoder in  https://github.com/nteract/scrapbook/issues/65.