### PR TITLE
Import ABC from collections.abc instead of collections for Python 3 compatibility

### DIFF
--- a/scrapbook/encoders.py
+++ b/scrapbook/encoders.py
@@ -7,7 +7,7 @@ Provides the encoders for various data types to be persistable
 import six
 import json
 import base64
-import collections
+import collections.abc
 import pandas as pd
 
 from io import BytesIO
@@ -18,7 +18,7 @@ from .scraps import scrap_to_payload
 from .exceptions import ScrapbookException, ScrapbookInvalidEncoder, ScrapbookMissingEncoder
 
 
-class DataEncoderRegistry(collections.MutableMapping):
+class DataEncoderRegistry(collections.abc.MutableMapping):
     def __init__(self):
         self._encoders = OrderedDict()
 

--- a/scrapbook/models.py
+++ b/scrapbook/models.py
@@ -311,7 +311,7 @@ class Notebook(object):
                 ip_display(data, metadata=metadata, raw=True)
 
 
-class Scrapbook(collections.MutableMapping):
+class Scrapbook(collections.abc.MutableMapping):
     """
     A collection of notebooks represented as a dictionary of notebooks
     """


### PR DESCRIPTION
Fixes #73 