### PR TITLE
Authorize filter read notebooks

### DIFF
--- a/scrapbook/api.py
+++ b/scrapbook/api.py
@@ -130,7 +130,7 @@ def read_notebook(path):
     return Notebook(path)
 
 
-def read_notebooks(path):
+def read_notebooks(path, path_filter=None):
     """
     Returns a Scrapbook including the notebooks read from the
     directory specified by `path`.
@@ -139,6 +139,9 @@ def read_notebooks(path):
     ----------
     path : str
         Path to directory containing notebook `.ipynb` files.
+    path_filter: Optional[Callable[str, bool]]
+        Func used to filter the notebook by its filename:
+        should return True if you want to read that notebook and False otherwise
 
     Returns
     -------
@@ -147,7 +150,7 @@ def read_notebooks(path):
 
     """
     scrapbook = Scrapbook()
-    for notebook_path in sorted(list_notebook_files(path)):
+    for notebook_path in sorted(filter(path_filter, list_notebook_files(path))):
         fn = os.path.splitext(os.path.basename(notebook_path))[0]
         scrapbook[fn] = read_notebook(notebook_path)
     return scrapbook

--- a/scrapbook/tests/test_api.py
+++ b/scrapbook/tests/test_api.py
@@ -287,4 +287,4 @@ def test_filter_filenames(mock_read_notebook, mock_list_notebook_files):
     mock_read_notebook.reset_mock()
     _ = read_notebooks('fake_path', path_filter=lambda x: 'test' in x)
     assert mock_read_notebook.call_count == 1
-    assert mock_read_notebook.assert_called_with('test')
+    mock_read_notebook.assert_called_with('test')

--- a/scrapbook/tests/test_api.py
+++ b/scrapbook/tests/test_api.py
@@ -9,7 +9,7 @@ from IPython.display import Image
 
 from . import get_fixture_path
 from .. import utils
-from ..api import glue
+from ..api import glue, read_notebooks
 from ..schemas import GLUE_PAYLOAD_FMT
 
 
@@ -276,3 +276,15 @@ def test_glue_warning(kernel_mock):
     kernel_mock.return_value = False
     with pytest.warns(UserWarning):
         glue('foo', 'bar', 'text')
+
+
+@mock.patch("scrapbook.api.list_notebook_files")
+@mock.patch("scrapbook.api.read_notebook")
+def test_filter_filenames(mock_read_notebook, mock_list_notebook_files):
+    mock_list_notebook_files.return_value = ['test', 'an', 'oo']
+    _ = read_notebooks('fake_path')
+    assert mock_read_notebook.call_count == 3
+    mock_read_notebook.reset_mock()
+    _ = read_notebooks('fake_path', path_filter=lambda x: 'test' in x)
+    assert mock_read_notebook.call_count == 1
+    assert mock_read_notebook.assert_called_with('test')


### PR DESCRIPTION
fix https://github.com/nteract/scrapbook/issues/81

Optional filter_path 
````
    Parameters
    ----------
    path : str
        Path to directory containing notebook `.ipynb` files.
    path_filter: Optional[Callable[str, bool]]
        Func used to filter the notebook by its filename:
        should return True if you want to read that notebook and False otherwise

    Returns
    -------
    scrapbook : object
        A `Scrapbook` object.

```